### PR TITLE
feat: add project scaffold for lean-consensus

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/lean-consensus.cabal
+++ b/lean-consensus.cabal
@@ -3,6 +3,7 @@ name:            lean-consensus
 version:         0.1.0.0
 synopsis:        Haskell Lean Consensus client for pq-devnet-3
 license:         MIT
+license-file:    LICENSE
 build-type:      Simple
 
 common warnings
@@ -26,9 +27,15 @@ library
         TypeApplications
     exposed-modules:
         LeanConsensus
+        SSZ
     build-depends:
         base          >= 4.18  && < 5
       , bytestring    >= 0.11  && < 0.13
+      , crypton       >= 0.34  && < 1.1
+      , memory        >= 0.18  && < 0.19
+      , vector        >= 0.13  && < 0.14
+      , containers    >= 0.6   && < 0.8
+      , text          >= 2.0   && < 2.2
 
 executable lean-consensus
     import:           warnings
@@ -53,5 +60,9 @@ test-suite lean-consensus-test
     build-depends:
         base            >= 4.18 && < 5
       , lean-consensus
+      , bytestring
+      , vector
       , tasty           >= 1.4  && < 1.6
       , tasty-hunit     >= 0.10 && < 0.11
+      , tasty-quickcheck >= 0.10 && < 0.12
+      , QuickCheck      >= 2.14 && < 2.16

--- a/src/SSZ.hs
+++ b/src/SSZ.hs
@@ -1,0 +1,1 @@
+module SSZ where


### PR DESCRIPTION
## Summary
- Add `lean-consensus.cabal` with library, executable, and test-suite components targeting GHC 9.6.7 / GHC2021
- Create placeholder `src/SSZ.hs`, `app/Main.hs`, `test/Main.hs`, `cabal.project`, and `LICENSE`
- All components build with `-Werror`, tests run (0 tests), executable prints `lean-consensus`

Closes #6 (Phase 1 / Step 1)

## Test plan
- [x] `cabal build all --ghc-options=-Werror` — zero warnings
- [x] `cabal test` — 0 tests passed
- [x] `cabal run lean-consensus` — prints "lean-consensus"

🤖 Generated with [Claude Code](https://claude.com/claude-code)