### PR TITLE
chore: add project scaffold and GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: GHC ${{ matrix.ghc }} / ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        ghc: ['9.6.7']
+        cabal: ['3.14.2']
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Haskell
+        uses: haskell-actions/setup@v2
+        with:
+          ghc-version: ${{ matrix.ghc }}
+          cabal-version: ${{ matrix.cabal }}
+
+      - name: Cache cabal store
+        uses: actions/cache@v4
+        with:
+          path: ~/.cabal/store
+          key: ${{ runner.os }}-ghc-${{ matrix.ghc }}-cabal-${{ hashFiles('**/*.cabal', 'cabal.project') }}
+          restore-keys: |
+            ${{ runner.os }}-ghc-${{ matrix.ghc }}-cabal-
+
+      - name: Update cabal index
+        run: cabal update
+
+      - name: Build dependencies
+        run: cabal build --only-dependencies
+
+      - name: Build
+        run: cabal build
+
+      - name: Run tests
+        run: cabal test --test-show-details=direct
+
+      - name: Check documentation
+        run: cabal haddock

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,0 +1,6 @@
+module Main (main) where
+
+import LeanConsensus (version)
+
+main :: IO ()
+main = putStrLn $ "lean-consensus v" <> version

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,1 @@
+packages: .

--- a/lean-consensus.cabal
+++ b/lean-consensus.cabal
@@ -1,0 +1,57 @@
+cabal-version:   3.0
+name:            lean-consensus
+version:         0.1.0.0
+synopsis:        Haskell Lean Consensus client for pq-devnet-3
+license:         MIT
+build-type:      Simple
+
+common warnings
+    ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates
+                 -Wincomplete-uni-patterns -Wmissing-home-modules
+                 -Wpartial-fields -Wredundant-constraints
+
+library
+    import:           warnings
+    hs-source-dirs:   src
+    default-language: GHC2021
+    default-extensions:
+        DataKinds
+        TypeFamilies
+        GADTs
+        StandaloneDeriving
+        DerivingStrategies
+        GeneralizedNewtypeDeriving
+        OverloadedStrings
+        ScopedTypeVariables
+        TypeApplications
+    exposed-modules:
+        LeanConsensus
+    build-depends:
+        base          >= 4.18  && < 5
+      , bytestring    >= 0.11  && < 0.13
+
+executable lean-consensus
+    import:           warnings
+    main-is:          Main.hs
+    hs-source-dirs:   app
+    default-language: GHC2021
+    build-depends:
+        base >= 4.18 && < 5
+      , lean-consensus
+
+test-suite lean-consensus-test
+    import:           warnings
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    hs-source-dirs:   test
+    default-language: GHC2021
+    default-extensions:
+        DataKinds
+        TypeApplications
+        ScopedTypeVariables
+        OverloadedStrings
+    build-depends:
+        base            >= 4.18 && < 5
+      , lean-consensus
+      , tasty           >= 1.4  && < 1.6
+      , tasty-hunit     >= 0.10 && < 0.11

--- a/src/LeanConsensus.hs
+++ b/src/LeanConsensus.hs
@@ -1,0 +1,6 @@
+module LeanConsensus
+  ( version
+  ) where
+
+version :: String
+version = "0.1.0.0"

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,0 +1,15 @@
+module Main (main) where
+
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import LeanConsensus (version)
+
+main :: IO ()
+main = defaultMain tests
+
+tests :: TestTree
+tests = testGroup "lean-consensus"
+  [ testCase "version is not empty" $
+      assertBool "version should not be empty" (not $ null version)
+  ]


### PR DESCRIPTION
## Summary
- Add minimal Cabal project scaffold (library, executable, test suite) with GHC2021 and tasty
- Set up GitHub Actions CI workflow: GHC 9.6.7 + Cabal 3.14.2, dependency caching, build, test, and haddock

## Test plan
- [ ] CI workflow runs successfully on this PR
- [ ] `cabal build` passes
- [ ] `cabal test` passes (1 smoke test)
- [ ] `cabal haddock` generates docs without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)