### PR TITLE
feat: implement SSZ foundation (Phase 1 complete)

### DIFF
--- a/lean-consensus.cabal
+++ b/lean-consensus.cabal
@@ -9,7 +9,7 @@ build-type:      Simple
 common warnings
     ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates
                  -Wincomplete-uni-patterns -Wmissing-home-modules
-                 -Wpartial-fields -Wredundant-constraints
+                 -Wpartial-fields -Wredundant-constraints -Werror
 
 library
     import:           warnings
@@ -25,9 +25,21 @@ library
         OverloadedStrings
         ScopedTypeVariables
         TypeApplications
+        FlexibleContexts
+        FlexibleInstances
     exposed-modules:
         LeanConsensus
         SSZ
+        SSZ.Bitlist
+        SSZ.Bitvector
+        SSZ.Common
+        SSZ.Container
+        SSZ.Derive
+        SSZ.List
+        SSZ.Merkleization
+        SSZ.Vector
+        Consensus.Constants
+        Consensus.Types
     build-depends:
         base          >= 4.18  && < 5
       , bytestring    >= 0.11  && < 0.13
@@ -57,6 +69,19 @@ test-suite lean-consensus-test
         TypeApplications
         ScopedTypeVariables
         OverloadedStrings
+        DerivingStrategies
+        FlexibleContexts
+        FlexibleInstances
+    other-modules:
+        Test.SSZ.Bitlist
+        Test.SSZ.Bitvector
+        Test.SSZ.Common
+        Test.SSZ.Derive
+        Test.SSZ.List
+        Test.SSZ.Merkleization
+        Test.SSZ.Support
+        Test.SSZ.Vector
+        Test.Consensus.Types
     build-depends:
         base            >= 4.18 && < 5
       , lean-consensus

--- a/src/Consensus/Constants.hs
+++ b/src/Consensus/Constants.hs
@@ -1,0 +1,103 @@
+-- | Consensus protocol constants and type aliases for pq-devnet-3.
+module Consensus.Constants
+  ( -- * Type aliases
+    Slot
+  , Epoch
+  , ValidatorIndex
+  , CommitteeIndex
+  , SubnetId
+  , Gwei
+  , Root
+  , Domain
+  , Version
+  , DomainType
+    -- * Timing
+  , slotDuration
+  , networkDelayBound
+    -- * Finality
+  , slotsToFinality
+    -- * Type-level constants
+  , MAX_VALIDATORS_PER_SUBNET
+  , MAX_ATTESTATIONS
+  , MAX_ATTESTATIONS_STATE
+  , SLOTS_PER_HISTORICAL_ROOT
+  , VALIDATOR_REGISTRY_LIMIT
+    -- * Crypto sizes
+  , xmssSignatureSize
+  , xmssPubkeySize
+    -- * Networking
+  , gossipsubMeshSize
+  , gossipsubHeartbeatMs
+  ) where
+
+import Data.Word (Word64)
+import SSZ.Common (Bytes4, Bytes32)
+
+-- ---------------------------------------------------------------------------
+-- Type aliases
+-- ---------------------------------------------------------------------------
+
+type Slot           = Word64
+type Epoch          = Word64
+type ValidatorIndex = Word64
+type CommitteeIndex = Word64
+type SubnetId       = Word64
+type Gwei           = Word64
+type Root           = Bytes32
+type Domain         = Bytes32
+type Version        = Bytes4
+type DomainType     = Bytes4
+
+-- ---------------------------------------------------------------------------
+-- Timing
+-- ---------------------------------------------------------------------------
+
+-- | Slot duration in microseconds (4 seconds).
+slotDuration :: Int
+slotDuration = 4_000_000
+
+-- | Network delay bound in microseconds (Δ = 800ms).
+networkDelayBound :: Int
+networkDelayBound = 800_000
+
+-- ---------------------------------------------------------------------------
+-- Finality
+-- ---------------------------------------------------------------------------
+
+-- | Number of slots to finality (3-slot finality).
+slotsToFinality :: Word64
+slotsToFinality = 3
+
+-- ---------------------------------------------------------------------------
+-- Type-level constants for SSZ collections
+-- ---------------------------------------------------------------------------
+
+type MAX_VALIDATORS_PER_SUBNET = 256
+type MAX_ATTESTATIONS          = 128
+type MAX_ATTESTATIONS_STATE    = 4096
+type SLOTS_PER_HISTORICAL_ROOT = 64
+type VALIDATOR_REGISTRY_LIMIT  = 1024
+
+-- ---------------------------------------------------------------------------
+-- Crypto sizes
+-- ---------------------------------------------------------------------------
+
+-- | XMSS signature size in bytes.
+xmssSignatureSize :: Int
+xmssSignatureSize = 3112
+
+-- | XMSS public key size in bytes.
+-- Defaulting to 32 bytes (Merkle tree root only).
+-- TODO: Verify against actual leanSig C library headers when obtained.
+xmssPubkeySize :: Int
+xmssPubkeySize = 32
+
+-- ---------------------------------------------------------------------------
+-- Networking
+-- ---------------------------------------------------------------------------
+
+gossipsubMeshSize :: Int
+gossipsubMeshSize = 8
+
+gossipsubHeartbeatMs :: Int
+gossipsubHeartbeatMs = 700

--- a/src/Consensus/Types.hs
+++ b/src/Consensus/Types.hs
@@ -1,0 +1,283 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+-- | Consensus types for pq-devnet-3.
+-- All SSZ-serializable types derive Generic and use SSZ.Derive for instances.
+module Consensus.Types
+  ( -- * Crypto primitives
+    XmssSignature (..)
+  , mkXmssSignature
+  , XmssPubkey (..)
+  , mkXmssPubkey
+  , LeanMultisigProof (..)
+    -- * Core types
+  , Checkpoint (..)
+  , AttestationData (..)
+  , SignedAttestation (..)
+  , SignedAggregatedAttestation (..)
+  , BeaconBlockBody (..)
+  , BeaconBlock (..)
+  , SignedBeaconBlock (..)
+  , BeaconBlockHeader (..)
+  , Validator (..)
+  , BeaconState (..)
+    -- * Fork choice (non-SSZ)
+  , Store (..)
+  , LatestMessage (..)
+  ) where
+
+import Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
+import Data.Map.Strict (Map)
+import GHC.Generics (Generic, Rep)
+import SSZ.Bitlist (Bitlist)
+import SSZ.Common
+import SSZ.Container ()
+import SSZ.Derive
+import SSZ.List (SszList)
+import SSZ.Merkleization (SszHashTreeRoot (..), merkleize, mixInLength, pack)
+import SSZ.Vector (SszVector)
+import Consensus.Constants
+
+-- ---------------------------------------------------------------------------
+-- Crypto primitives (opaque ByteString wrappers)
+-- ---------------------------------------------------------------------------
+
+-- | XMSS signature (3112 bytes, fixed-size in SSZ).
+newtype XmssSignature = XmssSignature { unXmssSignature :: ByteString }
+  deriving stock (Eq, Show)
+
+mkXmssSignature :: ByteString -> Either SszError XmssSignature
+mkXmssSignature bs
+  | BS.length bs == xmssSignatureSize = Right (XmssSignature bs)
+  | otherwise = Left (InvalidLength xmssSignatureSize (BS.length bs))
+
+instance Ssz XmssSignature where
+  sszFixedSize = Just (fromIntegral xmssSignatureSize)
+
+instance SszEncode XmssSignature where
+  sszEncode = unXmssSignature
+
+instance SszDecode XmssSignature where
+  sszDecode bs = mkXmssSignature bs
+
+instance SszHashTreeRoot XmssSignature where
+  hashTreeRoot (XmssSignature bs) =
+    case mkBytesN @3112 bs of
+      Right bn -> hashTreeRoot bn
+      Left _   -> error "XmssSignature: invalid length"
+
+-- | XMSS public key (xmssPubkeySize bytes, fixed-size in SSZ).
+newtype XmssPubkey = XmssPubkey { unXmssPubkey :: ByteString }
+  deriving stock (Eq, Show)
+
+mkXmssPubkey :: ByteString -> Either SszError XmssPubkey
+mkXmssPubkey bs
+  | BS.length bs == xmssPubkeySize = Right (XmssPubkey bs)
+  | otherwise = Left (InvalidLength xmssPubkeySize (BS.length bs))
+
+instance Ssz XmssPubkey where
+  sszFixedSize = Just (fromIntegral xmssPubkeySize)
+
+instance SszEncode XmssPubkey where
+  sszEncode = unXmssPubkey
+
+instance SszDecode XmssPubkey where
+  sszDecode bs = mkXmssPubkey bs
+
+instance SszHashTreeRoot XmssPubkey where
+  hashTreeRoot (XmssPubkey bs) =
+    case mkBytesN @32 bs of
+      Right bn -> hashTreeRoot bn
+      Left _   -> error "XmssPubkey: invalid length"
+
+-- | ZK proof from leanMultisig aggregation (variable-size).
+newtype LeanMultisigProof = LeanMultisigProof { unLeanMultisigProof :: ByteString }
+  deriving stock (Eq, Show)
+
+instance Ssz LeanMultisigProof where
+  sszFixedSize = Nothing
+
+instance SszEncode LeanMultisigProof where
+  sszEncode = unLeanMultisigProof
+
+instance SszDecode LeanMultisigProof where
+  sszDecode = Right . LeanMultisigProof
+
+instance SszHashTreeRoot LeanMultisigProof where
+  hashTreeRoot (LeanMultisigProof bs) =
+    let chunks = pack [bs]
+        limit  = max 1 (fromIntegral ((BS.length bs + 31) `div` 32))
+    in  mixInLength (merkleize chunks limit) (fromIntegral (BS.length bs))
+
+-- ---------------------------------------------------------------------------
+-- Core consensus types
+-- ---------------------------------------------------------------------------
+
+data Checkpoint = Checkpoint
+  { cpSlot :: !Slot
+  , cpRoot :: !Root
+  } deriving stock (Generic, Eq, Show)
+
+instance Ssz Checkpoint where
+  sszFixedSize = genericSszFixedSize @(Rep Checkpoint)
+instance SszEncode Checkpoint where
+  sszEncode = genericSszEncode
+instance SszDecode Checkpoint where
+  sszDecode = genericSszDecode
+instance SszHashTreeRoot Checkpoint where
+  hashTreeRoot = genericHashTreeRoot
+
+data AttestationData = AttestationData
+  { adSlot             :: !Slot
+  , adHeadRoot         :: !Root
+  , adSourceCheckpoint :: !Checkpoint
+  , adTargetCheckpoint :: !Checkpoint
+  } deriving stock (Generic, Eq, Show)
+
+instance Ssz AttestationData where
+  sszFixedSize = genericSszFixedSize @(Rep AttestationData)
+instance SszEncode AttestationData where
+  sszEncode = genericSszEncode
+instance SszDecode AttestationData where
+  sszDecode = genericSszDecode
+instance SszHashTreeRoot AttestationData where
+  hashTreeRoot = genericHashTreeRoot
+
+data SignedAttestation = SignedAttestation
+  { saData           :: !AttestationData
+  , saValidatorIndex :: !ValidatorIndex
+  , saSignature      :: !XmssSignature
+  } deriving stock (Generic, Eq, Show)
+
+instance Ssz SignedAttestation where
+  sszFixedSize = genericSszFixedSize @(Rep SignedAttestation)
+instance SszEncode SignedAttestation where
+  sszEncode = genericSszEncode
+instance SszDecode SignedAttestation where
+  sszDecode = genericSszDecode
+instance SszHashTreeRoot SignedAttestation where
+  hashTreeRoot = genericHashTreeRoot
+
+data SignedAggregatedAttestation = SignedAggregatedAttestation
+  { saaData             :: !AttestationData
+  , saaAggregationBits  :: !(Bitlist MAX_VALIDATORS_PER_SUBNET)
+  , saaAggregationProof :: !LeanMultisigProof
+  } deriving stock (Generic, Eq, Show)
+
+instance Ssz SignedAggregatedAttestation where
+  sszFixedSize = genericSszFixedSize @(Rep SignedAggregatedAttestation)
+instance SszEncode SignedAggregatedAttestation where
+  sszEncode = genericSszEncode
+instance SszDecode SignedAggregatedAttestation where
+  sszDecode = genericSszDecode
+
+data BeaconBlockBody = BeaconBlockBody
+  { bbbAttestations :: !(SszList MAX_ATTESTATIONS SignedAggregatedAttestation)
+  } deriving stock (Generic, Eq, Show)
+
+instance Ssz BeaconBlockBody where
+  sszFixedSize = genericSszFixedSize @(Rep BeaconBlockBody)
+instance SszEncode BeaconBlockBody where
+  sszEncode = genericSszEncode
+instance SszDecode BeaconBlockBody where
+  sszDecode = genericSszDecode
+
+data BeaconBlock = BeaconBlock
+  { bbSlot          :: !Slot
+  , bbProposerIndex :: !ValidatorIndex
+  , bbParentRoot    :: !Root
+  , bbStateRoot     :: !Root
+  , bbBody          :: !BeaconBlockBody
+  } deriving stock (Generic, Eq, Show)
+
+instance Ssz BeaconBlock where
+  sszFixedSize = genericSszFixedSize @(Rep BeaconBlock)
+instance SszEncode BeaconBlock where
+  sszEncode = genericSszEncode
+instance SszDecode BeaconBlock where
+  sszDecode = genericSszDecode
+
+data SignedBeaconBlock = SignedBeaconBlock
+  { sbbBlock     :: !BeaconBlock
+  , sbbSignature :: !XmssSignature
+  } deriving stock (Generic, Eq, Show)
+
+instance Ssz SignedBeaconBlock where
+  sszFixedSize = genericSszFixedSize @(Rep SignedBeaconBlock)
+instance SszEncode SignedBeaconBlock where
+  sszEncode = genericSszEncode
+instance SszDecode SignedBeaconBlock where
+  sszDecode = genericSszDecode
+
+data BeaconBlockHeader = BeaconBlockHeader
+  { bbhSlot          :: !Slot
+  , bbhProposerIndex :: !ValidatorIndex
+  , bbhParentRoot    :: !Root
+  , bbhStateRoot     :: !Root
+  , bbhBodyRoot      :: !Root
+  } deriving stock (Generic, Eq, Show)
+
+instance Ssz BeaconBlockHeader where
+  sszFixedSize = genericSszFixedSize @(Rep BeaconBlockHeader)
+instance SszEncode BeaconBlockHeader where
+  sszEncode = genericSszEncode
+instance SszDecode BeaconBlockHeader where
+  sszDecode = genericSszDecode
+instance SszHashTreeRoot BeaconBlockHeader where
+  hashTreeRoot = genericHashTreeRoot
+
+data Validator = Validator
+  { vPubkey           :: !XmssPubkey
+  , vEffectiveBalance :: !Gwei
+  , vSlashed          :: !Bool
+  , vActivationSlot   :: !Slot
+  , vExitSlot         :: !Slot
+  , vWithdrawableSlot :: !Slot
+  } deriving stock (Generic, Eq, Show)
+
+instance Ssz Validator where
+  sszFixedSize = genericSszFixedSize @(Rep Validator)
+instance SszEncode Validator where
+  sszEncode = genericSszEncode
+instance SszDecode Validator where
+  sszDecode = genericSszDecode
+instance SszHashTreeRoot Validator where
+  hashTreeRoot = genericHashTreeRoot
+
+data BeaconState = BeaconState
+  { bsSlot                :: !Slot
+  , bsLatestBlockHeader   :: !BeaconBlockHeader
+  , bsBlockRoots          :: !(SszVector SLOTS_PER_HISTORICAL_ROOT Root)
+  , bsStateRoots          :: !(SszVector SLOTS_PER_HISTORICAL_ROOT Root)
+  , bsValidators          :: !(SszList VALIDATOR_REGISTRY_LIMIT Validator)
+  , bsBalances            :: !(SszList VALIDATOR_REGISTRY_LIMIT Gwei)
+  , bsJustifiedCheckpoint :: !Checkpoint
+  , bsFinalizedCheckpoint :: !Checkpoint
+  , bsCurrentAttestations :: !(SszList MAX_ATTESTATIONS_STATE SignedAggregatedAttestation)
+  } deriving stock (Generic, Eq, Show)
+
+instance Ssz BeaconState where
+  sszFixedSize = genericSszFixedSize @(Rep BeaconState)
+instance SszEncode BeaconState where
+  sszEncode = genericSszEncode
+instance SszDecode BeaconState where
+  sszDecode = genericSszDecode
+
+-- ---------------------------------------------------------------------------
+-- Fork choice types (not SSZ-serialized)
+-- ---------------------------------------------------------------------------
+
+data Store = Store
+  { stJustifiedCheckpoint :: !Checkpoint
+  , stFinalizedCheckpoint :: !Checkpoint
+  , stBlocks              :: !(Map Root BeaconBlock)
+  , stBlockStates         :: !(Map Root BeaconState)
+  , stLatestMessages      :: !(Map ValidatorIndex LatestMessage)
+  , stCurrentSlot         :: !Slot
+  } deriving stock (Eq, Show)
+
+data LatestMessage = LatestMessage
+  { lmSlot :: !Slot
+  , lmRoot :: !Root
+  } deriving stock (Eq, Show)

--- a/src/SSZ.hs
+++ b/src/SSZ.hs
@@ -1,1 +1,17 @@
-module SSZ where
+module SSZ
+  ( module SSZ.Common
+  , module SSZ.Container
+  , module SSZ.Derive
+  , module SSZ.List
+  , module SSZ.Vector
+  , module SSZ.Bitvector
+  , module SSZ.Bitlist
+  ) where
+
+import SSZ.Bitlist
+import SSZ.Bitvector
+import SSZ.Common
+import SSZ.Container
+import SSZ.Derive
+import SSZ.List
+import SSZ.Vector

--- a/src/SSZ/Bitlist.hs
+++ b/src/SSZ/Bitlist.hs
@@ -1,0 +1,117 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+
+-- | SSZ variable-length bit array with sentinel bit.
+module SSZ.Bitlist
+  ( Bitlist
+  , mkBitlist
+  , unBitlist
+  , bitlistLen
+  , getBitlistBit
+  ) where
+
+import Data.Bits (clearBit, setBit, testBit)
+import Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
+import Data.Proxy (Proxy (..))
+import Data.Word (Word8)
+import GHC.TypeNats (KnownNat, Nat, natVal)
+import SSZ.Common
+
+-- | Variable-length bit array with max capacity @n@. Constructor is hidden.
+-- Internally stores the bits WITHOUT the sentinel (just the data bits packed).
+-- The sentinel is added/removed during encode/decode.
+data Bitlist (n :: Nat) = UnsafeBitlist
+  { blBits   :: !ByteString  -- ^ packed data bits (no sentinel)
+  , blLength :: !Int          -- ^ number of data bits
+  }
+  deriving stock (Eq, Show)
+
+-- | Smart constructor from a list of bools.
+mkBitlist :: forall n. KnownNat n => [Bool] -> Either SszError (Bitlist n)
+mkBitlist bits
+  | numBits > maxCap = Left (InvalidLength maxCap numBits)
+  | otherwise        = Right (UnsafeBitlist (packBitsRaw bits) numBits)
+  where
+    numBits = length bits
+    maxCap  = fromIntegral (natVal (Proxy @n))
+
+-- | Raw bytes (without sentinel).
+unBitlist :: Bitlist n -> ByteString
+unBitlist = blBits
+
+-- | Number of data bits.
+bitlistLen :: Bitlist n -> Int
+bitlistLen = blLength
+
+-- | Get bit at index.
+getBitlistBit :: Bitlist n -> Int -> Bool
+getBitlistBit (UnsafeBitlist bs _) i =
+  let byteIdx = i `div` 8
+      bitIdx  = i `mod` 8
+  in  testBit (BS.index bs byteIdx) bitIdx
+
+-- | Pack bits into bytes, LSB first (no sentinel).
+packBitsRaw :: [Bool] -> ByteString
+packBitsRaw bits =
+  let numBytes = (length bits + 7) `div` 8
+      buildByte byteIdx =
+        foldl (\acc bitIdx ->
+          let globalIdx = byteIdx * 8 + bitIdx
+          in  if globalIdx < length bits && bits !! globalIdx
+                then setBit acc bitIdx
+                else acc
+        ) (0 :: Word8) [0..7]
+  in  BS.pack [buildByte i | i <- [0 .. numBytes - 1]]
+
+-- | Variable-size.
+instance Ssz (Bitlist n) where
+  sszFixedSize = Nothing
+
+-- | Encode: pack bits + append sentinel bit.
+instance SszEncode (Bitlist n) where
+  sszEncode (UnsafeBitlist _ numBits) | numBits == 0 =
+    -- Empty bitlist: just the sentinel byte 0x01
+    BS.singleton 0x01
+  sszEncode bl@(UnsafeBitlist _packed numBits) =
+    -- Re-pack all bits including the sentinel
+    let sentinelIdx = numBits  -- sentinel goes right after last data bit
+        totalBits   = numBits + 1
+        numBytes    = (totalBits + 7) `div` 8
+        buildByte byteIdx =
+          foldl (\acc bitIdx ->
+            let globalIdx = byteIdx * 8 + bitIdx
+            in  if globalIdx == sentinelIdx
+                  then setBit acc bitIdx   -- sentinel bit
+                  else if globalIdx < numBits && getBitlistBit bl globalIdx
+                    then setBit acc bitIdx
+                    else acc
+          ) (0 :: Word8) [0..7]
+    in  BS.pack [buildByte i | i <- [0 .. numBytes - 1]]
+
+-- | Decode: find sentinel bit, everything below is data.
+instance KnownNat n => SszDecode (Bitlist n) where
+  sszDecode bs = do
+    let maxCap = fromIntegral (natVal (Proxy @n)) :: Int
+    if BS.null bs
+      then Left InvalidSentinel
+      else do
+        -- Find the sentinel: highest set bit in the last byte
+        let lastByte = BS.index bs (BS.length bs - 1)
+        sentinelBitInByte <- findHighestSetBit lastByte
+        let numBits = (BS.length bs - 1) * 8 + sentinelBitInByte
+        if numBits > maxCap
+          then Left (InvalidLength maxCap numBits)
+          else do
+            -- Clear the sentinel bit and keep just the data
+            let cleared = BS.init bs `BS.snoc` clearBit lastByte sentinelBitInByte
+                dataBytes = BS.take ((numBits + 7) `div` 8) cleared
+            Right (UnsafeBitlist dataBytes numBits)
+
+-- | Find the index of the highest set bit in a byte. Returns error if 0.
+findHighestSetBit :: Word8 -> Either SszError Int
+findHighestSetBit 0 = Left InvalidSentinel
+findHighestSetBit b = Right (go 7)
+  where
+    go i
+      | testBit b i = i
+      | otherwise   = go (i - 1)

--- a/src/SSZ/Bitvector.hs
+++ b/src/SSZ/Bitvector.hs
@@ -1,0 +1,79 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+
+-- | SSZ fixed-length bit array.
+module SSZ.Bitvector
+  ( Bitvector
+  , mkBitvector
+  , unBitvector
+  , bitvectorBits
+  , getBit
+  ) where
+
+import Data.Bits (setBit, shiftR, testBit)
+import Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
+import Data.Proxy (Proxy (..))
+import Data.Word (Word8)
+import GHC.TypeNats (KnownNat, Nat, natVal)
+import SSZ.Common
+
+-- | Fixed-length bit array of @n@ bits. Constructor is hidden.
+newtype Bitvector (n :: Nat) = UnsafeBitvector ByteString
+  deriving stock (Eq, Ord, Show)
+
+-- | Smart constructor from a list of bools.
+mkBitvector :: forall n. KnownNat n => [Bool] -> Either SszError (Bitvector n)
+mkBitvector bits
+  | length bits /= numBits = Left (InvalidLength numBits (length bits))
+  | otherwise              = Right (UnsafeBitvector (packBits bits))
+  where
+    numBits = fromIntegral (natVal (Proxy @n))
+
+-- | Raw bytes.
+unBitvector :: Bitvector n -> ByteString
+unBitvector (UnsafeBitvector bs) = bs
+
+-- | Number of bits.
+bitvectorBits :: forall n. KnownNat n => Bitvector n -> Int
+bitvectorBits _ = fromIntegral (natVal (Proxy @n))
+
+-- | Get bit at index (0-based, LSB first within each byte).
+getBit :: Bitvector n -> Int -> Bool
+getBit (UnsafeBitvector bs) i =
+  let byteIdx = i `div` 8
+      bitIdx  = i `mod` 8
+  in  testBit (BS.index bs byteIdx) bitIdx
+
+-- | Pack bits into bytes, LSB first.
+packBits :: [Bool] -> ByteString
+packBits bits =
+  let numBytes = (length bits + 7) `div` 8
+      buildByte byteIdx =
+        foldl (\acc bitIdx ->
+          let globalIdx = byteIdx * 8 + bitIdx
+          in  if globalIdx < length bits && bits !! globalIdx
+                then setBit acc bitIdx
+                else acc
+        ) (0 :: Word8) [0..7]
+  in  BS.pack [buildByte i | i <- [0 .. numBytes - 1]]
+
+-- | Serialized size: ceil(n / 8) bytes. Fixed-size.
+instance KnownNat n => Ssz (Bitvector n) where
+  sszFixedSize = Just (fromIntegral ((natVal (Proxy @n) + 7) `div` 8))
+
+instance KnownNat n => SszEncode (Bitvector n) where
+  sszEncode (UnsafeBitvector bs) = bs
+
+instance KnownNat n => SszDecode (Bitvector n) where
+  sszDecode bs = do
+    let numBits = fromIntegral (natVal (Proxy @n)) :: Int
+        expectedBytes = (numBits + 7) `div` 8
+    if BS.length bs /= expectedBytes
+      then Left (InvalidLength expectedBytes (BS.length bs))
+      else do
+        -- Verify unused high bits in last byte are zero
+        let lastByte = BS.index bs (expectedBytes - 1)
+            usedBits = numBits `mod` 8
+        if usedBits /= 0 && lastByte `shiftR` usedBits /= 0
+          then Left (ExtraBytes (fromIntegral lastByte))
+          else Right (UnsafeBitvector bs)

--- a/src/SSZ/Common.hs
+++ b/src/SSZ/Common.hs
@@ -1,0 +1,187 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+
+module SSZ.Common
+  ( -- * Error types
+    SszError (..)
+    -- * Typeclasses
+  , Ssz (..)
+  , sszIsFixedSize
+  , SszEncode (..)
+  , SszDecode (..)
+    -- * BytesN (constructor hidden)
+  , BytesN
+  , mkBytesN
+  , unBytesN
+  , zeroN
+    -- * Type aliases
+  , Bytes4
+  , Bytes20
+  , Bytes32
+  , Bytes48
+  , Bytes96
+  , Uint128
+  , Uint256
+  ) where
+
+import Data.Bits (shiftL, (.|.))
+import Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
+import Data.ByteString.Builder (toLazyByteString, word16LE, word32LE, word64LE)
+import qualified Data.ByteString.Lazy as LBS
+import Data.Maybe (isJust)
+import Data.Proxy (Proxy (..))
+import Data.Word (Word8, Word16, Word32, Word64)
+import GHC.TypeNats (KnownNat, Nat, natVal)
+
+-- | SSZ decoding errors.
+data SszError
+  = InvalidLength Int Int -- ^ expected, actual
+  | InvalidOffset Word32
+  | ExtraBytes Int
+  | InvalidBool Word8
+  | InvalidSentinel
+  | CustomError String
+  deriving stock (Show, Eq)
+
+-- | Typeclass for SSZ metadata. Returns the fixed size of a type, or
+-- 'Nothing' for variable-size types.
+class Ssz a where
+  sszFixedSize :: Maybe Word32
+
+-- | Convenience function: check whether a type is fixed-size.
+sszIsFixedSize :: forall a. Ssz a => Bool
+sszIsFixedSize = isJust (sszFixedSize @a)
+
+-- | Typeclass for SSZ encoding.
+class Ssz a => SszEncode a where
+  sszEncode :: a -> ByteString
+
+-- | Typeclass for SSZ decoding.
+class Ssz a => SszDecode a where
+  sszDecode :: ByteString -> Either SszError a
+
+-- | Fixed-length byte array, parameterised by its size at the type level.
+-- The constructor is intentionally not exported; use 'mkBytesN' to create
+-- values.
+newtype BytesN (n :: Nat) = UnsafeBytesN ByteString
+  deriving stock (Eq, Ord, Show)
+
+-- | Smart constructor for 'BytesN'. Returns 'Left' if the input length does
+-- not match @n@.
+mkBytesN :: forall n. KnownNat n => ByteString -> Either SszError (BytesN n)
+mkBytesN bs
+  | BS.length bs == len = Right (UnsafeBytesN bs)
+  | otherwise           = Left (InvalidLength len (BS.length bs))
+  where
+    len = fromIntegral (natVal (Proxy @n))
+
+-- | Unwrap a 'BytesN' to a raw 'ByteString'.
+unBytesN :: BytesN n -> ByteString
+unBytesN (UnsafeBytesN bs) = bs
+
+-- | Create a zero-filled 'BytesN'.
+zeroN :: forall n. KnownNat n => BytesN n
+zeroN = UnsafeBytesN (BS.replicate (fromIntegral (natVal (Proxy @n))) 0)
+
+-- Type aliases
+type Bytes4  = BytesN 4
+type Bytes20 = BytesN 20
+type Bytes32 = BytesN 32
+type Bytes48 = BytesN 48
+type Bytes96 = BytesN 96
+type Uint128 = BytesN 16
+type Uint256 = BytesN 32
+
+-- ---------------------------------------------------------------------------
+-- Ssz instances
+-- ---------------------------------------------------------------------------
+
+instance Ssz Word8 where
+  sszFixedSize = Just 1
+
+instance Ssz Word16 where
+  sszFixedSize = Just 2
+
+instance Ssz Word32 where
+  sszFixedSize = Just 4
+
+instance Ssz Word64 where
+  sszFixedSize = Just 8
+
+instance Ssz Bool where
+  sszFixedSize = Just 1
+
+instance KnownNat n => Ssz (BytesN n) where
+  sszFixedSize = Just (fromIntegral (natVal (Proxy @n)))
+
+-- ---------------------------------------------------------------------------
+-- SszEncode instances
+-- ---------------------------------------------------------------------------
+
+instance SszEncode Word8 where
+  sszEncode w = BS.singleton w
+
+instance SszEncode Word16 where
+  sszEncode = LBS.toStrict . toLazyByteString . word16LE
+
+instance SszEncode Word32 where
+  sszEncode = LBS.toStrict . toLazyByteString . word32LE
+
+instance SszEncode Word64 where
+  sszEncode = LBS.toStrict . toLazyByteString . word64LE
+
+instance SszEncode Bool where
+  sszEncode True  = BS.singleton 0x01
+  sszEncode False = BS.singleton 0x00
+
+instance KnownNat n => SszEncode (BytesN n) where
+  sszEncode = unBytesN
+
+-- ---------------------------------------------------------------------------
+-- SszDecode instances
+-- ---------------------------------------------------------------------------
+
+instance SszDecode Word8 where
+  sszDecode bs
+    | BS.length bs == 1 = Right (BS.index bs 0)
+    | otherwise         = Left (InvalidLength 1 (BS.length bs))
+
+instance SszDecode Word16 where
+  sszDecode bs
+    | BS.length bs == 2 =
+        Right $  fromIntegral (BS.index bs 0)
+            .|. (fromIntegral (BS.index bs 1) `shiftL` 8)
+    | otherwise = Left (InvalidLength 2 (BS.length bs))
+
+instance SszDecode Word32 where
+  sszDecode bs
+    | BS.length bs == 4 =
+        Right $  fromIntegral (BS.index bs 0)
+            .|. (fromIntegral (BS.index bs 1) `shiftL` 8)
+            .|. (fromIntegral (BS.index bs 2) `shiftL` 16)
+            .|. (fromIntegral (BS.index bs 3) `shiftL` 24)
+    | otherwise = Left (InvalidLength 4 (BS.length bs))
+
+instance SszDecode Word64 where
+  sszDecode bs
+    | BS.length bs == 8 =
+        Right $  fromIntegral (BS.index bs 0)
+            .|. (fromIntegral (BS.index bs 1) `shiftL` 8)
+            .|. (fromIntegral (BS.index bs 2) `shiftL` 16)
+            .|. (fromIntegral (BS.index bs 3) `shiftL` 24)
+            .|. (fromIntegral (BS.index bs 4) `shiftL` 32)
+            .|. (fromIntegral (BS.index bs 5) `shiftL` 40)
+            .|. (fromIntegral (BS.index bs 6) `shiftL` 48)
+            .|. (fromIntegral (BS.index bs 7) `shiftL` 56)
+    | otherwise = Left (InvalidLength 8 (BS.length bs))
+
+instance SszDecode Bool where
+  sszDecode bs
+    | BS.length bs /= 1 = Left (InvalidLength 1 (BS.length bs))
+    | otherwise = case BS.index bs 0 of
+        0x00 -> Right False
+        0x01 -> Right True
+        w    -> Left (InvalidBool w)
+
+instance KnownNat n => SszDecode (BytesN n) where
+  sszDecode = mkBytesN

--- a/src/SSZ/Container.hs
+++ b/src/SSZ/Container.hs
@@ -1,0 +1,109 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+
+-- | Reusable two-pass container encoding and decoding helpers.
+-- Used by both manual container instances and GHC.Generics auto-derivation.
+module SSZ.Container
+  ( -- * Encoder
+    SszEncoder
+  , emptyEncoder
+  , addFixedField
+  , addVariableField
+  , finalizeEncoder
+    -- * Decoder
+  , FieldKind (..)
+  , decodeContainer
+  ) where
+
+import Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
+import Data.Word (Word32)
+import SSZ.Common (SszDecode (..), SszEncode (..), SszError (..))
+
+-- ---------------------------------------------------------------------------
+-- Two-pass encoder
+-- ---------------------------------------------------------------------------
+
+-- | A field descriptor: either fixed bytes inline or variable bytes deferred.
+data FieldEntry
+  = FixedEntry !ByteString
+  | VariableEntry !ByteString
+
+-- | Collects field entries. Offsets are computed only in 'finalizeEncoder'.
+newtype SszEncoder = SszEncoder [FieldEntry]
+
+emptyEncoder :: SszEncoder
+emptyEncoder = SszEncoder []
+
+-- | Append a fixed-size field.
+addFixedField :: SszEncode a => a -> SszEncoder -> SszEncoder
+addFixedField a (SszEncoder fs) = SszEncoder (fs ++ [FixedEntry (sszEncode a)])
+
+-- | Append a variable-size field.
+addVariableField :: SszEncode a => a -> SszEncoder -> SszEncoder
+addVariableField a (SszEncoder fs) = SszEncoder (fs ++ [VariableEntry (sszEncode a)])
+
+-- | Compute offsets and produce the final serialized container.
+finalizeEncoder :: SszEncoder -> ByteString
+finalizeEncoder (SszEncoder fs) =
+  let -- Total fixed region size: sum of fixed field sizes + 4 bytes per variable field
+      fixedRegionSize = sum
+        [ case f of
+            FixedEntry bs  -> fromIntegral (BS.length bs)
+            VariableEntry _ -> 4
+        | f <- fs
+        ]
+      -- Build fixed and variable regions
+      (fixedParts, varParts, _) = foldl go ([], [], fixedRegionSize) fs
+      go (fixed, var, varOffset) (FixedEntry bs) =
+        (fixed ++ [bs], var, varOffset)
+      go (fixed, var, varOffset) (VariableEntry bs) =
+        let offsetBs = sszEncode (varOffset :: Word32)
+        in  (fixed ++ [offsetBs], var ++ [bs], varOffset + fromIntegral (BS.length bs))
+  in  BS.concat fixedParts <> BS.concat varParts
+
+-- ---------------------------------------------------------------------------
+-- Container decoder
+-- ---------------------------------------------------------------------------
+
+-- | Describes whether a field in a container is fixed or variable size.
+data FieldKind
+  = FixedField !Word32  -- ^ field size in bytes
+  | VariableField       -- ^ variable-size (4-byte offset in fixed region)
+
+-- | Decode a container: given the field layout, split input into per-field
+-- ByteStrings that can then be decoded individually.
+decodeContainer :: [FieldKind] -> ByteString -> Either SszError [ByteString]
+decodeContainer fields bs = do
+  let fixedRegionSize = sum
+        [ case f of FixedField n -> n; VariableField -> 4
+        | f <- fields
+        ]
+  if fromIntegral fixedRegionSize > BS.length bs
+    then Left (InvalidLength (fromIntegral fixedRegionSize) (BS.length bs))
+    else extractFields fields 0 (fromIntegral fixedRegionSize) bs
+
+extractFields :: [FieldKind] -> Int -> Int -> ByteString -> Either SszError [ByteString]
+extractFields [] _ _ _ = Right []
+extractFields (FixedField n : rest) cursor totalFixed input = do
+  let slice = BS.take (fromIntegral n) (BS.drop cursor input)
+  remaining <- extractFields rest (cursor + fromIntegral n) totalFixed input
+  Right (slice : remaining)
+extractFields (VariableField : rest) cursor totalFixed input = do
+  -- Read the 4-byte offset at cursor
+  offset <- sszDecode @Word32 (BS.take 4 (BS.drop cursor input))
+  -- End of this variable field = next variable field's offset or end of input
+  varEnd <- findVarEnd rest (cursor + 4) totalFixed input
+  let start = fromIntegral offset
+      slice = BS.take (varEnd - start) (BS.drop start input)
+  remaining <- extractFields rest (cursor + 4) totalFixed input
+  Right (slice : remaining)
+
+-- | Find where the current variable field ends: either the offset of the
+-- next variable field, or the end of the input.
+findVarEnd :: [FieldKind] -> Int -> Int -> ByteString -> Either SszError Int
+findVarEnd [] _ _ input = Right (BS.length input)
+findVarEnd (FixedField n : rest) cursor totalFixed input =
+  findVarEnd rest (cursor + fromIntegral n) totalFixed input
+findVarEnd (VariableField : _) cursor _ input = do
+  offset <- sszDecode @Word32 (BS.take 4 (BS.drop cursor input))
+  Right (fromIntegral offset)

--- a/src/SSZ/Derive.hs
+++ b/src/SSZ/Derive.hs
@@ -1,0 +1,172 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+-- | GHC.Generics-based auto-derivation for SSZ Container types.
+--
+-- Usage:
+--
+-- @
+-- data Checkpoint = Checkpoint { cpSlot :: Word64, cpRoot :: Bytes32 }
+--   deriving stock (Generic, Eq, Show)
+--
+-- instance Ssz Checkpoint where
+--   sszFixedSize = genericSszFixedSize \@(Rep Checkpoint)
+--
+-- instance SszEncode Checkpoint where
+--   sszEncode = genericSszEncode
+--
+-- instance SszDecode Checkpoint where
+--   sszDecode = genericSszDecode
+--
+-- instance SszHashTreeRoot Checkpoint where
+--   hashTreeRoot = genericHashTreeRoot
+-- @
+module SSZ.Derive
+  ( genericSszFixedSize
+  , genericSszEncode
+  , genericSszDecode
+  , genericHashTreeRoot
+  ) where
+
+import Data.ByteString (ByteString)
+import Data.Kind (Type)
+import Data.Word (Word32)
+import GHC.Generics
+import SSZ.Common
+import SSZ.Container
+import SSZ.Merkleization (SszHashTreeRoot (..), merkleize)
+
+-- ---------------------------------------------------------------------------
+-- Public API
+-- ---------------------------------------------------------------------------
+
+-- | Compute the fixed size of a Generic container.
+-- Returns 'Nothing' if any field is variable-size.
+-- Each variable-size field contributes 4 bytes (offset) to the fixed region.
+genericSszFixedSize :: forall f. GSsz f => Maybe Word32
+genericSszFixedSize = gsszFixedSize @f
+
+-- | Encode a Generic container using two-pass serialization.
+genericSszEncode :: (Generic a, GEncode (Rep a)) => a -> ByteString
+genericSszEncode a = finalizeEncoder (gAddFields (from a) emptyEncoder)
+
+-- | Decode a Generic container from bytes.
+genericSszDecode :: forall a. (Generic a, GDecode (Rep a)) => ByteString -> Either SszError a
+genericSszDecode bs = do
+  let kinds = gFieldKinds @(Rep a)
+  slices <- decodeContainer kinds bs
+  (rep, _) <- gFromSlices slices
+  Right (to rep)
+
+-- | Compute hashTreeRoot of a Generic container:
+-- merkleize(map hashTreeRoot fields).
+genericHashTreeRoot :: (Generic a, GHashTreeRoot (Rep a)) => a -> ByteString
+genericHashTreeRoot a =
+  let roots = gFieldRoots (from a)
+      numFields = fromIntegral (length roots)
+  in  merkleize roots numFields
+
+-- ---------------------------------------------------------------------------
+-- GSsz: Generic metadata
+-- ---------------------------------------------------------------------------
+
+class GSsz (f :: Type -> Type) where
+  -- | Container fixed size: sum of field sizes (4 for variable-size fields).
+  -- Returns Nothing if any field is variable-size.
+  gsszFixedSize :: Maybe Word32
+  -- | Total fixed region size (counts 4 bytes per variable field).
+  gsszFixedRegionSize :: Word32
+
+instance GSsz f => GSsz (M1 i c f) where
+  gsszFixedSize = gsszFixedSize @f
+  gsszFixedRegionSize = gsszFixedRegionSize @f
+
+instance (GSsz f, GSsz g) => GSsz (f :*: g) where
+  gsszFixedSize = case (gsszFixedSize @f, gsszFixedSize @g) of
+    (Just a, Just b) -> Just (a + b)
+    _                -> Nothing
+  gsszFixedRegionSize = gsszFixedRegionSize @f + gsszFixedRegionSize @g
+
+instance Ssz a => GSsz (K1 i a) where
+  gsszFixedSize = sszFixedSize @a
+  gsszFixedRegionSize = case sszFixedSize @a of
+    Just n  -> n
+    Nothing -> 4  -- offset placeholder
+
+instance GSsz U1 where
+  gsszFixedSize = Just 0
+  gsszFixedRegionSize = 0
+
+-- ---------------------------------------------------------------------------
+-- GEncode: Generic encoding
+-- ---------------------------------------------------------------------------
+
+class GEncode (f :: Type -> Type) where
+  gAddFields :: f p -> SszEncoder -> SszEncoder
+
+instance GEncode f => GEncode (M1 i c f) where
+  gAddFields (M1 x) = gAddFields x
+
+instance (GEncode f, GEncode g) => GEncode (f :*: g) where
+  gAddFields (l :*: r) = gAddFields r . gAddFields l
+
+instance (SszEncode a, Ssz a) => GEncode (K1 i a) where
+  gAddFields (K1 a) enc = case sszFixedSize @a of
+    Just _  -> addFixedField a enc
+    Nothing -> addVariableField a enc
+
+instance GEncode U1 where
+  gAddFields U1 = id
+
+-- ---------------------------------------------------------------------------
+-- GDecode: Generic decoding
+-- ---------------------------------------------------------------------------
+
+class GDecode (f :: Type -> Type) where
+  gFieldKinds :: [FieldKind]
+  gFromSlices :: [ByteString] -> Either SszError (f p, [ByteString])
+
+instance GDecode f => GDecode (M1 i c f) where
+  gFieldKinds = gFieldKinds @f
+  gFromSlices slices = do
+    (x, rest) <- gFromSlices @f slices
+    Right (M1 x, rest)
+
+instance (GDecode f, GDecode g) => GDecode (f :*: g) where
+  gFieldKinds = gFieldKinds @f ++ gFieldKinds @g
+  gFromSlices slices = do
+    (l, rest1) <- gFromSlices @f slices
+    (r, rest2) <- gFromSlices @g rest1
+    Right (l :*: r, rest2)
+
+instance (SszDecode a, Ssz a) => GDecode (K1 i a) where
+  gFieldKinds = case sszFixedSize @a of
+    Just n  -> [FixedField n]
+    Nothing -> [VariableField]
+  gFromSlices [] = Left (CustomError "not enough fields to decode")
+  gFromSlices (s : rest) = do
+    a <- sszDecode s
+    Right (K1 a, rest)
+
+instance GDecode U1 where
+  gFieldKinds = []
+  gFromSlices slices = Right (U1, slices)
+
+-- ---------------------------------------------------------------------------
+-- GHashTreeRoot: Generic hashTreeRoot for containers
+-- ---------------------------------------------------------------------------
+
+class GHashTreeRoot (f :: Type -> Type) where
+  gFieldRoots :: f p -> [ByteString]
+
+instance GHashTreeRoot f => GHashTreeRoot (M1 i c f) where
+  gFieldRoots (M1 x) = gFieldRoots x
+
+instance (GHashTreeRoot f, GHashTreeRoot g) => GHashTreeRoot (f :*: g) where
+  gFieldRoots (l :*: r) = gFieldRoots l ++ gFieldRoots r
+
+instance SszHashTreeRoot a => GHashTreeRoot (K1 i a) where
+  gFieldRoots (K1 a) = [hashTreeRoot a]
+
+instance GHashTreeRoot U1 where
+  gFieldRoots U1 = []

--- a/src/SSZ/List.hs
+++ b/src/SSZ/List.hs
@@ -1,0 +1,89 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+
+-- | SSZ variable-length list with max capacity.
+module SSZ.List
+  ( SszList
+  , mkSszList
+  , unSszList
+  ) where
+
+import Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
+import Data.Proxy (Proxy (..))
+import Data.Word (Word32)
+import GHC.TypeNats (KnownNat, Nat, natVal)
+import SSZ.Common
+
+-- | Variable-length list with max capacity @n@ (type-level).
+-- Constructor is hidden; use 'mkSszList'.
+newtype SszList (n :: Nat) a = UnsafeSszList [a]
+  deriving stock (Eq, Show)
+
+-- | Smart constructor. Validates that length does not exceed max capacity.
+mkSszList :: forall n a. KnownNat n => [a] -> Either SszError (SszList n a)
+mkSszList xs
+  | length xs > maxCap = Left (InvalidLength maxCap (length xs))
+  | otherwise          = Right (UnsafeSszList xs)
+  where
+    maxCap = fromIntegral (natVal (Proxy @n))
+
+-- | Unwrap.
+unSszList :: SszList n a -> [a]
+unSszList (UnsafeSszList xs) = xs
+
+-- SszList is always variable-size.
+instance Ssz (SszList n a) where
+  sszFixedSize = Nothing
+
+-- | Encode: fixed-size elements → concatenate; variable-size → offset table + data.
+instance (SszEncode a, Ssz a) => SszEncode (SszList n a) where
+  sszEncode (UnsafeSszList xs) =
+    case sszFixedSize @a of
+      Just _  -> BS.concat (map sszEncode xs)
+      Nothing ->
+        let encoded = map sszEncode xs
+            numElems = length xs
+            offsetTableSize = numElems * 4
+            -- Each offset = offsetTableSize + sum of encoded sizes before this element
+            offsets = scanl (\acc bs -> acc + BS.length bs) offsetTableSize encoded
+            -- scanl produces numElems+1 entries; take first numElems
+            offsetBytes = map (sszEncode . (fromIntegral :: Int -> Word32)) (take numElems offsets)
+        in  BS.concat offsetBytes <> BS.concat encoded
+
+-- | Decode: fixed-size elements → split by element size; variable-size → offset table.
+instance (KnownNat n, SszDecode a, Ssz a) => SszDecode (SszList n a) where
+  sszDecode bs = do
+    let maxCap = fromIntegral (natVal (Proxy @n)) :: Int
+    xs <- case sszFixedSize @a of
+      Just elemSize ->
+        let es = fromIntegral elemSize
+        in  if not (BS.null bs) && BS.length bs `mod` es /= 0
+              then Left (InvalidLength es (BS.length bs))
+              else mapM sszDecode (chunksOf es bs)
+      Nothing -> decodeVariableList bs
+    if length xs > maxCap
+      then Left (InvalidLength maxCap (length xs))
+      else Right (UnsafeSszList xs)
+
+-- | Split a ByteString into chunks of a given size.
+chunksOf :: Int -> ByteString -> [ByteString]
+chunksOf _ bs | BS.null bs = []
+chunksOf n bs = BS.take n bs : chunksOf n (BS.drop n bs)
+
+-- | Decode a list of variable-size elements using offset table.
+decodeVariableList :: SszDecode a => ByteString -> Either SszError [a]
+decodeVariableList bs
+  | BS.null bs = Right []
+  | BS.length bs < 4 = Left (InvalidLength 4 (BS.length bs))
+  | otherwise = do
+      firstOffset <- sszDecode @Word32 (BS.take 4 bs)
+      let numElems = fromIntegral firstOffset `div` 4
+      if numElems == 0
+        then Right []
+        else do
+          offsets <- mapM (\i -> sszDecode @Word32 (BS.take 4 (BS.drop (i * 4) bs)))
+                         [0 .. numElems - 1]
+          let ends = map fromIntegral (drop 1 offsets) ++ [BS.length bs]
+              starts = map fromIntegral offsets
+              slices = zipWith (\s e -> BS.take (e - s) (BS.drop s bs)) starts ends
+          mapM sszDecode slices

--- a/src/SSZ/Merkleization.hs
+++ b/src/SSZ/Merkleization.hs
@@ -1,0 +1,222 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+
+-- | SSZ Merkleization: hash_tree_root computation using SHA-256.
+module SSZ.Merkleization
+  ( -- * Hashing
+    sha256
+  , sha256Pair
+    -- * Chunking
+  , pack
+  , packBits
+    -- * Merkle tree
+  , merkleize
+  , mixInLength
+  , zeroHashes
+    -- * Typeclass
+  , SszHashTreeRoot (..)
+  ) where
+
+import qualified Crypto.Hash as CH
+import qualified Data.ByteArray as BA
+import Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
+import Data.Proxy (Proxy (..))
+import qualified Data.Vector as V
+import Data.Word (Word8, Word16, Word32, Word64)
+import GHC.TypeNats (KnownNat, natVal)
+import SSZ.Bitvector (Bitvector, unBitvector)
+import SSZ.Bitlist (Bitlist, unBitlist, bitlistLen)
+import SSZ.Common
+import SSZ.List (SszList, unSszList)
+import SSZ.Vector (SszVector, unSszVector)
+
+-- ---------------------------------------------------------------------------
+-- SHA-256
+-- ---------------------------------------------------------------------------
+
+-- | SHA-256 hash via crypton.
+sha256 :: ByteString -> ByteString
+sha256 bs = BA.convert (CH.hash bs :: CH.Digest CH.SHA256)
+
+-- | SHA-256 of two concatenated ByteStrings.
+sha256Pair :: ByteString -> ByteString -> ByteString
+sha256Pair a b = sha256 (a <> b)
+
+-- ---------------------------------------------------------------------------
+-- Chunking
+-- ---------------------------------------------------------------------------
+
+-- | Zero-pad and split into 32-byte chunks.
+-- If input is empty, returns one zero chunk.
+pack :: [ByteString] -> [ByteString]
+pack bss =
+  let concatenated = BS.concat bss
+      padded = zeroPadTo32 concatenated
+  in  chunksOf 32 padded
+  where
+    zeroPadTo32 bs
+      | BS.null bs = BS.replicate 32 0
+      | otherwise  =
+          let remainder = BS.length bs `mod` 32
+          in  if remainder == 0
+                then bs
+                else bs <> BS.replicate (32 - remainder) 0
+
+-- | Pack bits into 32-byte chunks (for Bitvector/Bitlist).
+packBits :: [Bool] -> [ByteString]
+packBits bits =
+  let -- Pack bits into bytes, LSB first
+      numBytes = (length bits + 7) `div` 8
+      buildByte byteIdx =
+        foldl (\acc bitIdx ->
+          let globalIdx = byteIdx * 8 + bitIdx
+              bit = if globalIdx < length bits && bits !! globalIdx then 1 else 0
+          in  acc + bit * (2 ^ bitIdx)
+        ) (0 :: Word8) [0..7]
+      packed = BS.pack [buildByte i | i <- [0 .. numBytes - 1]]
+  in  pack [packed]
+
+-- | Split a ByteString into chunks of a given size.
+chunksOf :: Int -> ByteString -> [ByteString]
+chunksOf _ bs | BS.null bs = []
+chunksOf n bs = BS.take n bs : chunksOf n (BS.drop n bs)
+
+-- ---------------------------------------------------------------------------
+-- Merkle tree
+-- ---------------------------------------------------------------------------
+
+-- | Pre-computed zero hashes. zeroHashes[0] = 32 zero bytes,
+-- zeroHashes[i] = sha256(zeroHashes[i-1] ++ zeroHashes[i-1]).
+zeroHashes :: V.Vector ByteString
+zeroHashes = V.generate 64 go
+  where
+    go 0 = BS.replicate 32 0
+    go i = let prev = zeroHashes V.! (i - 1)
+           in  sha256Pair prev prev
+
+-- | Compute the Merkle root of chunks with a given limit.
+-- The tree depth is determined by the limit (next power of 2).
+-- Chunks are padded with zero hashes to fill the tree.
+merkleize :: [ByteString] -> Word64 -> ByteString
+merkleize chunks limit =
+  let depth = if limit <= 1 then 0 else ceilLog2 limit
+  in  go chunks depth 0
+  where
+    -- Recursively hash pairs up to the root
+    go [single] 0 _ = single
+    go _ 0 _level = error "merkleize: too many chunks for depth 0"
+    go cs d level =
+      let padded = padToEven cs level
+          paired = pairHash padded
+      in  go paired (d - 1) (level + 1)
+
+    -- Pad the chunk list to an even number, using zero hashes at the given level
+    padToEven cs level
+      | even (length cs) = cs
+      | otherwise        = cs ++ [zeroHashes V.! level]
+
+    -- Hash adjacent pairs
+    pairHash [] = []
+    pairHash [x] = [x]  -- shouldn't happen after padding
+    pairHash (x : y : rest) = sha256Pair x y : pairHash rest
+
+    -- Ceiling log2
+    ceilLog2 :: Word64 -> Int
+    ceilLog2 1 = 0
+    ceilLog2 n = 1 + ceilLog2 ((n + 1) `div` 2)
+
+-- | Mix in the length for variable-size types.
+-- result = SHA-256(root ++ little_endian_64(length))
+mixInLength :: ByteString -> Word64 -> ByteString
+mixInLength root len =
+  sha256Pair root (sszEncode len)
+
+-- ---------------------------------------------------------------------------
+-- SszHashTreeRoot typeclass
+-- ---------------------------------------------------------------------------
+
+-- | Compute the hash tree root of an SSZ value.
+class Ssz a => SszHashTreeRoot a where
+  hashTreeRoot :: a -> ByteString
+
+-- Basic types: merkleize(pack([encode(value)]))
+instance SszHashTreeRoot Word8 where
+  hashTreeRoot = head . pack . pure . sszEncode
+
+instance SszHashTreeRoot Word16 where
+  hashTreeRoot = head . pack . pure . sszEncode
+
+instance SszHashTreeRoot Word32 where
+  hashTreeRoot = head . pack . pure . sszEncode
+
+instance SszHashTreeRoot Word64 where
+  hashTreeRoot = head . pack . pure . sszEncode
+
+instance SszHashTreeRoot Bool where
+  hashTreeRoot = head . pack . pure . sszEncode
+
+-- BytesN: merkleize(pack([value]), limit=ceil(n/32))
+instance KnownNat n => SszHashTreeRoot (BytesN n) where
+  hashTreeRoot bn =
+    let n = natVal (Proxy @n)
+        limit = fromIntegral ((n + 31) `div` 32)
+        chunks = pack [unBytesN bn]
+    in  merkleize chunks limit
+
+-- Bitvector: merkleize(packBits(bits), limit=ceil(n/256))
+instance KnownNat n => SszHashTreeRoot (Bitvector n) where
+  hashTreeRoot bv =
+    let n = natVal (Proxy @n)
+        limit = fromIntegral ((n + 255) `div` 256)
+        rawBytes = unBitvector bv
+        bits = [BS.index rawBytes (i `div` 8) `testBitAt` (i `mod` 8)
+               | i <- [0 .. fromIntegral n - 1]]
+        chunks = packBits bits
+    in  merkleize chunks limit
+
+-- Bitlist: mixInLength(merkleize(packBits(bits), limit=ceil(n/256)), len)
+instance KnownNat n => SszHashTreeRoot (Bitlist n) where
+  hashTreeRoot bl =
+    let n = natVal (Proxy @n)
+        limit = fromIntegral ((n + 255) `div` 256)
+        len = bitlistLen bl
+        rawBytes = unBitlist bl
+        bits = [BS.index rawBytes (i `div` 8) `testBitAt` (i `mod` 8)
+               | i <- [0 .. len - 1]]
+        chunks = packBits bits
+        root = merkleize chunks limit
+    in  mixInLength root (fromIntegral len)
+
+-- SszVector (fixed-size elements): merkleize(pack(map encode elems), limit=n)
+-- SszVector (composite elements): merkleize(map hashTreeRoot elems, limit=n)
+instance (KnownNat n, SszHashTreeRoot a, SszEncode a, Ssz a)
+      => SszHashTreeRoot (SszVector n a) where
+  hashTreeRoot sv =
+    let n = fromIntegral (natVal (Proxy @n))
+        elems = V.toList (unSszVector sv)
+    in  case sszFixedSize @a of
+          Just _ ->
+            let chunks = pack (map sszEncode elems)
+            in  merkleize chunks n
+          Nothing ->
+            merkleize (map hashTreeRoot elems) n
+
+-- SszList (fixed-size elements): mixInLength(merkleize(pack(map encode elems), limit=n), len)
+-- SszList (composite elements): mixInLength(merkleize(map hashTreeRoot elems, limit=n), len)
+instance (KnownNat n, SszHashTreeRoot a, SszEncode a, Ssz a)
+      => SszHashTreeRoot (SszList n a) where
+  hashTreeRoot sl =
+    let n = fromIntegral (natVal (Proxy @n))
+        elems = unSszList sl
+        len = fromIntegral (length elems)
+        root = case sszFixedSize @a of
+          Just _ ->
+            let chunks = pack (map sszEncode elems)
+            in  merkleize chunks n
+          Nothing ->
+            merkleize (map hashTreeRoot elems) n
+    in  mixInLength root len
+
+-- Helper: test a bit in a byte
+testBitAt :: Word8 -> Int -> Bool
+testBitAt byte bit = byte `div` (2 ^ bit) `mod` 2 == 1

--- a/src/SSZ/Vector.hs
+++ b/src/SSZ/Vector.hs
@@ -1,0 +1,84 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+
+-- | SSZ fixed-length vector.
+module SSZ.Vector
+  ( SszVector
+  , mkSszVector
+  , unSszVector
+  ) where
+
+import Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
+import Data.Proxy (Proxy (..))
+import qualified Data.Vector as V
+import Data.Word (Word32)
+import GHC.TypeNats (KnownNat, Nat, natVal)
+import SSZ.Common
+
+-- | Fixed-length homogeneous collection. Constructor is hidden; use 'mkSszVector'.
+newtype SszVector (n :: Nat) a = UnsafeSszVector (V.Vector a)
+  deriving stock (Eq, Show)
+
+-- | Smart constructor. Validates that length equals @n@.
+mkSszVector :: forall n a. KnownNat n => V.Vector a -> Either SszError (SszVector n a)
+mkSszVector v
+  | V.length v == expected = Right (UnsafeSszVector v)
+  | otherwise              = Left (InvalidLength expected (V.length v))
+  where
+    expected = fromIntegral (natVal (Proxy @n))
+
+-- | Unwrap.
+unSszVector :: SszVector n a -> V.Vector a
+unSszVector (UnsafeSszVector v) = v
+
+-- | Fixed-size iff element type is fixed-size.
+instance (KnownNat n, Ssz a) => Ssz (SszVector n a) where
+  sszFixedSize = case sszFixedSize @a of
+    Just elemSize -> Just (fromIntegral (natVal (Proxy @n)) * elemSize)
+    Nothing       -> Nothing
+
+-- | Encode: fixed elements → concatenate; variable elements → offset table + data.
+instance (KnownNat n, SszEncode a, Ssz a) => SszEncode (SszVector n a) where
+  sszEncode (UnsafeSszVector v) =
+    case sszFixedSize @a of
+      Just _  -> BS.concat (map sszEncode (V.toList v))
+      Nothing ->
+        let encoded = map sszEncode (V.toList v)
+            numElems = V.length v
+            offsetTableSize = numElems * 4
+            offsets = scanl (\acc bs -> acc + BS.length bs) offsetTableSize encoded
+            offsetBytes = map (sszEncode . (fromIntegral :: Int -> Word32)) (take numElems offsets)
+        in  BS.concat offsetBytes <> BS.concat encoded
+
+-- | Decode: fixed elements → split by element size; variable elements → offset table.
+instance (KnownNat n, SszDecode a, Ssz a) => SszDecode (SszVector n a) where
+  sszDecode bs = do
+    let expected = fromIntegral (natVal (Proxy @n)) :: Int
+    xs <- case sszFixedSize @a of
+      Just elemSize ->
+        let es = fromIntegral elemSize
+        in  if BS.length bs /= es * expected
+              then Left (InvalidLength (es * expected) (BS.length bs))
+              else mapM sszDecode (chunksOf es bs)
+      Nothing -> decodeVariableElements expected bs
+    if length xs /= expected
+      then Left (InvalidLength expected (length xs))
+      else Right (UnsafeSszVector (V.fromList xs))
+
+-- | Split a ByteString into chunks of a given size.
+chunksOf :: Int -> ByteString -> [ByteString]
+chunksOf _ bs | BS.null bs = []
+chunksOf n bs = BS.take n bs : chunksOf n (BS.drop n bs)
+
+-- | Decode variable-size elements from an offset table.
+decodeVariableElements :: SszDecode a => Int -> ByteString -> Either SszError [a]
+decodeVariableElements expected bs
+  | expected == 0 && BS.null bs = Right []
+  | BS.length bs < expected * 4 = Left (InvalidLength (expected * 4) (BS.length bs))
+  | otherwise = do
+      offsets <- mapM (\i -> sszDecode @Word32 (BS.take 4 (BS.drop (i * 4) bs)))
+                      [0 .. expected - 1]
+      let ends = map fromIntegral (drop 1 offsets) ++ [BS.length bs]
+          starts = map fromIntegral offsets
+          slices = zipWith (\s e -> BS.take (e - s) (BS.drop s bs)) starts ends
+      mapM sszDecode slices

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -4,6 +4,14 @@ import Test.Tasty
 import Test.Tasty.HUnit
 
 import LeanConsensus (version)
+import qualified Test.Consensus.Types as ConsensusTypes
+import qualified Test.SSZ.Bitlist as SSZBitlist
+import qualified Test.SSZ.Bitvector as SSZBitvector
+import qualified Test.SSZ.Common as SSZCommon
+import qualified Test.SSZ.Derive as SSZDerive
+import qualified Test.SSZ.List as SSZList
+import qualified Test.SSZ.Merkleization as SSZMerkleization
+import qualified Test.SSZ.Vector as SSZVector
 
 main :: IO ()
 main = defaultMain tests
@@ -12,4 +20,12 @@ tests :: TestTree
 tests = testGroup "lean-consensus"
   [ testCase "version is not empty" $
       assertBool "version should not be empty" (not $ null version)
+  , SSZCommon.tests
+  , SSZList.tests
+  , SSZVector.tests
+  , SSZBitvector.tests
+  , SSZBitlist.tests
+  , SSZMerkleization.tests
+  , SSZDerive.tests
+  , ConsensusTypes.tests
   ]

--- a/test/Test/Consensus/Types.hs
+++ b/test/Test/Consensus/Types.hs
@@ -1,0 +1,108 @@
+module Test.Consensus.Types (tests) where
+
+import qualified Data.ByteString as BS
+import Data.Word (Word64)
+import Test.Tasty
+import Test.Tasty.HUnit
+import SSZ.Common
+import SSZ.Merkleization (SszHashTreeRoot (..), merkleize)
+import Consensus.Constants
+import Consensus.Types
+
+-- | Helper: unwrap a Right or fail.
+unsafeRight :: (Show e) => Either e a -> a
+unsafeRight (Right a) = a
+unsafeRight (Left e)  = error ("expected Right, got Left: " ++ show e)
+
+-- | Create a zero Bytes32.
+zeroRoot :: Root
+zeroRoot = zeroN @32
+
+-- | Create a zero Checkpoint.
+zeroCheckpoint :: Checkpoint
+zeroCheckpoint = Checkpoint 0 zeroRoot
+
+-- | Create a zero AttestationData.
+zeroAttData :: AttestationData
+zeroAttData = AttestationData 0 zeroRoot zeroCheckpoint zeroCheckpoint
+
+-- | Create a zero BeaconBlockHeader.
+zeroBlockHeader :: BeaconBlockHeader
+zeroBlockHeader = BeaconBlockHeader 0 0 zeroRoot zeroRoot zeroRoot
+
+tests :: TestTree
+tests = testGroup "Consensus.Types"
+  [ testGroup "Ssz metadata"
+      [ testCase "Checkpoint is fixed-size, 40 bytes" $ do
+          sszFixedSize @Checkpoint @?= Just 40
+          sszIsFixedSize @Checkpoint @?= True
+      , testCase "AttestationData is fixed-size, 120 bytes" $ do
+          sszFixedSize @AttestationData @?= Just 120
+          sszIsFixedSize @AttestationData @?= True
+      , testCase "BeaconBlockHeader is fixed-size, 112 bytes" $ do
+          sszFixedSize @BeaconBlockHeader @?= Just 112
+          sszIsFixedSize @BeaconBlockHeader @?= True
+      , testCase "SignedAttestation is fixed-size" $
+          sszIsFixedSize @SignedAttestation @?= True
+      , testCase "SignedAggregatedAttestation is variable-size" $
+          sszIsFixedSize @SignedAggregatedAttestation @?= False
+      , testCase "BeaconState is variable-size" $
+          sszIsFixedSize @BeaconState @?= False
+      , testCase "Validator is fixed-size" $
+          sszIsFixedSize @Validator @?= True
+      , testCase "Validator size uses xmssPubkeySize" $ do
+          -- vPubkey(32) + vEffectiveBalance(8) + vSlashed(1) +
+          -- vActivationSlot(8) + vExitSlot(8) + vWithdrawableSlot(8) = 65
+          let expectedSize = fromIntegral xmssPubkeySize + 8 + 1 + 8 + 8 + 8
+          sszFixedSize @Validator @?= Just expectedSize
+      ]
+  , testGroup "roundtrip"
+      [ testCase "Checkpoint" $ do
+          let root = unsafeRight $ mkBytesN @32 (BS.pack [1..32])
+              cp = Checkpoint 42 root
+          sszDecode (sszEncode cp) @?= Right cp
+      , testCase "AttestationData" $ do
+          let root = unsafeRight $ mkBytesN @32 (BS.pack [1..32])
+              cp = Checkpoint 10 root
+              ad = AttestationData 5 root cp cp
+          sszDecode (sszEncode ad) @?= Right ad
+      , testCase "SignedAttestation" $ do
+          let sig = unsafeRight $ mkXmssSignature (BS.replicate xmssSignatureSize 0xAB)
+              sa = SignedAttestation zeroAttData 7 sig
+          sszDecode (sszEncode sa) @?= Right sa
+      , testCase "BeaconBlockHeader" $ do
+          let root = unsafeRight $ mkBytesN @32 (BS.pack [1..32])
+              bbh = BeaconBlockHeader 100 5 root root root
+          sszDecode (sszEncode bbh) @?= Right bbh
+      , testCase "Validator" $ do
+          let pk = unsafeRight $ mkXmssPubkey (BS.replicate xmssPubkeySize 0x01)
+              v = Validator pk 32000000 False 0 maxBound maxBound
+          sszDecode (sszEncode v) @?= Right v
+      ]
+  , testGroup "hashTreeRoot"
+      [ testCase "Checkpoint hashTreeRoot" $ do
+          let cp = Checkpoint 0 zeroRoot
+              slotRoot = hashTreeRoot (0 :: Word64)
+              rootRoot = hashTreeRoot zeroRoot
+              expected = merkleize [slotRoot, rootRoot] 2
+          hashTreeRoot cp @?= expected
+      , testCase "BeaconBlockHeader hashTreeRoot" $ do
+          let bbh = zeroBlockHeader
+              allRoots = [ hashTreeRoot (bbhSlot bbh)
+                         , hashTreeRoot (bbhProposerIndex bbh)
+                         , hashTreeRoot (bbhParentRoot bbh)
+                         , hashTreeRoot (bbhStateRoot bbh)
+                         , hashTreeRoot (bbhBodyRoot bbh)
+                         ]
+          -- 5 fields → merkleize with limit=5
+          hashTreeRoot bbh @?= merkleize allRoots 5
+      ]
+  , testGroup "constants"
+      [ testCase "slotDuration == 4_000_000" $
+          slotDuration @?= 4_000_000
+      , testCase "slotsToFinality == 3" $
+          slotsToFinality @?= 3
+      , testCase "xmssSignatureSize == 3112" $
+          xmssSignatureSize @?= 3112
+      ]
+  ]

--- a/test/Test/SSZ/Bitlist.hs
+++ b/test/Test/SSZ/Bitlist.hs
@@ -1,0 +1,73 @@
+module Test.SSZ.Bitlist (tests) where
+
+import qualified Data.ByteString as BS
+import Test.Tasty
+import Test.Tasty.HUnit
+import SSZ.Common
+import SSZ.Bitlist
+
+-- | Helper: unwrap a Right or fail the test.
+unsafeRight :: (Show e) => Either e a -> a
+unsafeRight (Right a) = a
+unsafeRight (Left e)  = error ("expected Right, got Left: " ++ show e)
+
+tests :: TestTree
+tests = testGroup "SSZ.Bitlist"
+  [ testGroup "mkBitlist"
+      [ testCase "accepts within capacity" $ do
+          case mkBitlist @64 (replicate 10 True) of
+            Right bl -> bitlistLen bl @?= 10
+            Left err -> assertFailure (show err)
+      , testCase "rejects exceeding capacity" $ do
+          case mkBitlist @4 (replicate 5 True) of
+            Left (InvalidLength 4 5) -> pure ()
+            other -> assertFailure ("expected InvalidLength 4 5, got " ++ show other)
+      ]
+  , testGroup "Ssz metadata"
+      [ testCase "Bitlist is variable-size" $
+          sszIsFixedSize @(Bitlist 64) @?= False
+      ]
+  , testGroup "encode/decode"
+      [ testCase "empty bitlist encodes as 0x01 (just sentinel)" $ do
+          let bl = unsafeRight $ mkBitlist @64 []
+          sszEncode bl @?= BS.singleton 0x01
+      , testCase "roundtrip empty bitlist" $ do
+          let bl = unsafeRight $ mkBitlist @64 []
+          fmap bitlistLen (sszDecode @(Bitlist 64) (sszEncode bl)) @?= Right 0
+      , testCase "roundtrip 3 bits [T,F,T]" $ do
+          let bits = [True, False, True]
+              bl = unsafeRight $ mkBitlist @64 bits
+          case sszDecode @(Bitlist 64) (sszEncode bl) of
+            Right bl' -> do
+              bitlistLen bl' @?= 3
+              [getBitlistBit bl' i | i <- [0..2]] @?= bits
+            Left err -> assertFailure (show err)
+      , testCase "roundtrip 8 bits (sentinel in next byte)" $ do
+          let bits = replicate 8 True
+              bl = unsafeRight $ mkBitlist @64 bits
+              encoded = sszEncode bl
+          BS.length encoded @?= 2  -- 8 data bits + sentinel = 9 bits = 2 bytes
+          fmap bitlistLen (sszDecode @(Bitlist 64) encoded) @?= Right 8
+      , testCase "roundtrip 7 bits (sentinel in same byte)" $ do
+          let bits = replicate 7 True
+              bl = unsafeRight $ mkBitlist @64 bits
+              encoded = sszEncode bl
+          BS.length encoded @?= 1  -- 7 data bits + sentinel = 8 bits = 1 byte
+          fmap bitlistLen (sszDecode @(Bitlist 64) encoded) @?= Right 7
+      , testCase "decode rejects missing sentinel (all zeros)" $ do
+          case sszDecode @(Bitlist 64) (BS.singleton 0x00) of
+            Left InvalidSentinel -> pure ()
+            other -> assertFailure ("expected InvalidSentinel, got " ++ show other)
+      , testCase "decode rejects empty input" $ do
+          case sszDecode @(Bitlist 64) BS.empty of
+            Left InvalidSentinel -> pure ()
+            other -> assertFailure ("expected InvalidSentinel, got " ++ show other)
+      , testCase "decode rejects exceeding capacity" $ do
+          let bits = replicate 10 False
+              bl = unsafeRight $ mkBitlist @64 bits
+              encoded = sszEncode bl
+          case sszDecode @(Bitlist 5) encoded of
+            Left (InvalidLength 5 10) -> pure ()
+            other -> assertFailure ("expected InvalidLength 5 10, got " ++ show other)
+      ]
+  ]

--- a/test/Test/SSZ/Bitvector.hs
+++ b/test/Test/SSZ/Bitvector.hs
@@ -1,0 +1,57 @@
+module Test.SSZ.Bitvector (tests) where
+
+import qualified Data.ByteString as BS
+import Test.Tasty
+import Test.Tasty.HUnit
+import SSZ.Common
+import SSZ.Bitvector
+
+-- | Helper: unwrap a Right or fail the test.
+unsafeRight :: (Show e) => Either e a -> a
+unsafeRight (Right a) = a
+unsafeRight (Left e)  = error ("expected Right, got Left: " ++ show e)
+
+tests :: TestTree
+tests = testGroup "SSZ.Bitvector"
+  [ testGroup "mkBitvector"
+      [ testCase "accepts correct bit count" $ do
+          case mkBitvector @8 (replicate 8 False) of
+            Right _  -> pure ()
+            Left err -> assertFailure (show err)
+      , testCase "rejects wrong bit count" $ do
+          case mkBitvector @8 (replicate 7 False) of
+            Left (InvalidLength 8 7) -> pure ()
+            other -> assertFailure ("expected InvalidLength 8 7, got " ++ show other)
+      ]
+  , testGroup "Ssz metadata"
+      [ testCase "Bitvector 16 is fixed-size" $
+          sszIsFixedSize @(Bitvector 16) @?= True
+      , testCase "Bitvector 16 fixed size == 2" $
+          sszFixedSize @(Bitvector 16) @?= Just 2
+      , testCase "Bitvector 10 fixed size == 2" $
+          sszFixedSize @(Bitvector 10) @?= Just 2
+      ]
+  , testGroup "encode/decode"
+      [ testCase "encode 8 bits all false" $ do
+          let bv = unsafeRight $ mkBitvector @8 (replicate 8 False)
+          sszEncode bv @?= BS.singleton 0x00
+      , testCase "encode 8 bits all true" $ do
+          let bv = unsafeRight $ mkBitvector @8 (replicate 8 True)
+          sszEncode bv @?= BS.singleton 0xFF
+      , testCase "encode bit 0 set (LSB first)" $ do
+          let bv = unsafeRight $ mkBitvector @8 (True : replicate 7 False)
+          sszEncode bv @?= BS.singleton 0x01
+      , testCase "roundtrip 16 bits" $ do
+          let bits = [True, False, True, True, False, False, True, False,
+                      False, True, False, False, True, True, False, False]
+              bv = unsafeRight $ mkBitvector @16 bits
+          case sszDecode @(Bitvector 16) (sszEncode bv) of
+            Right bv' -> [getBit bv' i | i <- [0..15]] @?= bits
+            Left err  -> assertFailure (show err)
+      , testCase "decode rejects non-zero unused bits" $ do
+          -- Bitvector 10 uses 2 bytes, but only 10 bits
+          case sszDecode @(Bitvector 10) (BS.pack [0xFF, 0xFF]) of
+            Left (ExtraBytes _) -> pure ()
+            other -> assertFailure ("expected ExtraBytes, got " ++ show other)
+      ]
+  ]

--- a/test/Test/SSZ/Common.hs
+++ b/test/Test/SSZ/Common.hs
@@ -1,0 +1,60 @@
+module Test.SSZ.Common (tests) where
+
+import qualified Data.ByteString as BS
+import Data.Word (Word32, Word64)
+import SSZ.Common
+import Test.SSZ.Support
+import Test.Tasty
+import Test.Tasty.HUnit
+import Test.Tasty.QuickCheck
+
+tests :: TestTree
+tests = testGroup "SSZ.Common"
+  [ testGroup "mkBytesN"
+      [ testCase "accepts correct length" $
+          case mkBytesN @32 (BS.replicate 32 0) of
+            Right _  -> pure ()
+            Left err -> assertFailure ("unexpected error: " <> show err)
+      , testCase "rejects wrong length" $
+          case mkBytesN @32 (BS.replicate 31 0) of
+            Left (InvalidLength 32 31) -> pure ()
+            Left err  -> assertFailure ("unexpected error shape: " <> show err)
+            Right _   -> assertFailure "should have rejected wrong length"
+      ]
+  , testGroup "Ssz metadata"
+      [ testCase "sszFixedSize @Word64 == Just 8" $
+          sszFixedSize @Word64 @?= Just 8
+      , testCase "sszFixedSize @Bool == Just 1" $
+          sszFixedSize @Bool @?= Just 1
+      , testCase "sszFixedSize @Bytes32 == Just 32" $
+          sszFixedSize @Bytes32 @?= Just 32
+      , testCase "sszIsFixedSize @Word32 is True" $
+          sszIsFixedSize @Word32 @?= True
+      ]
+  , testGroup "encode"
+      [ testCase "Word64 42 little-endian" $
+          sszEncode (42 :: Word64) @?= BS.pack [42, 0, 0, 0, 0, 0, 0, 0]
+      , testCase "Bool True == 0x01" $
+          sszEncode True @?= BS.singleton 0x01
+      , testCase "Bool False == 0x00" $
+          sszEncode False @?= BS.singleton 0x00
+      ]
+  , testGroup "decode"
+      [ testCase "Word64 roundtrip 42" $
+          sszDecode (BS.pack [42, 0, 0, 0, 0, 0, 0, 0]) @?= Right (42 :: Word64)
+      , testCase "Bool invalid byte" $
+          sszDecode @Bool (BS.singleton 0x02) @?= Left (InvalidBool 0x02)
+      , testCase "Word64 wrong length" $
+          sszDecode @Word64 (BS.pack [1, 2, 3]) @?= Left (InvalidLength 8 3)
+      ]
+  , testGroup "roundtrip properties"
+      [ testProperty "Word8 roundtrip" $ \(ArbWord8 w) -> roundtripProp w
+      , testProperty "Word16 roundtrip" $ \(ArbWord16 w) -> roundtripProp w
+      , testProperty "Word32 roundtrip" $ \(ArbWord32 w) -> roundtripProp w
+      , testProperty "Word64 roundtrip" $ \(ArbWord64 w) -> roundtripProp w
+      , testProperty "Bool roundtrip" $ \(ArbBool b) -> roundtripProp b
+      , testProperty "BytesN 32 roundtrip" $ \(ArbBytesN @32 bn) -> roundtripProp bn
+      , testProperty "BytesN 4 roundtrip" $ \(ArbBytesN @4 bn) -> roundtripProp bn
+      , testProperty "BytesN 96 roundtrip" $ \(ArbBytesN @96 bn) -> roundtripProp bn
+      ]
+  ]

--- a/test/Test/SSZ/Derive.hs
+++ b/test/Test/SSZ/Derive.hs
@@ -1,0 +1,135 @@
+module Test.SSZ.Derive (tests) where
+
+import qualified Data.ByteString as BS
+import Data.Word (Word64)
+import GHC.Generics (Generic, Rep)
+import Test.Tasty
+import Test.Tasty.HUnit
+import SSZ.Common
+import SSZ.Derive
+import SSZ.List (SszList, mkSszList)
+import SSZ.Merkleization
+
+-- ---------------------------------------------------------------------------
+-- Test container: all fixed fields
+-- ---------------------------------------------------------------------------
+
+data TestFixed = TestFixed
+  { tfSlot :: !Word64
+  , tfRoot :: !(BytesN 32)
+  } deriving stock (Generic, Eq, Show)
+
+instance Ssz TestFixed where
+  sszFixedSize = genericSszFixedSize @(Rep TestFixed)
+
+instance SszEncode TestFixed where
+  sszEncode = genericSszEncode
+
+instance SszDecode TestFixed where
+  sszDecode = genericSszDecode
+
+instance SszHashTreeRoot TestFixed where
+  hashTreeRoot = genericHashTreeRoot
+
+-- ---------------------------------------------------------------------------
+-- Test container: mixed fixed and variable fields
+-- ---------------------------------------------------------------------------
+
+data TestMixed = TestMixed
+  { tmSlot  :: !Word64
+  , tmItems :: !(SszList 100 Word64)
+  , tmFlag  :: !Bool
+  } deriving stock (Generic, Eq, Show)
+
+instance Ssz TestMixed where
+  sszFixedSize = genericSszFixedSize @(Rep TestMixed)
+
+instance SszEncode TestMixed where
+  sszEncode = genericSszEncode
+
+instance SszDecode TestMixed where
+  sszDecode = genericSszDecode
+
+-- ---------------------------------------------------------------------------
+-- Test container: nested container
+-- ---------------------------------------------------------------------------
+
+data TestNested = TestNested
+  { tnInner :: !TestFixed
+  , tnValue :: !Word64
+  } deriving stock (Generic, Eq, Show)
+
+instance Ssz TestNested where
+  sszFixedSize = genericSszFixedSize @(Rep TestNested)
+
+instance SszEncode TestNested where
+  sszEncode = genericSszEncode
+
+instance SszDecode TestNested where
+  sszDecode = genericSszDecode
+
+instance SszHashTreeRoot TestNested where
+  hashTreeRoot = genericHashTreeRoot
+
+-- ---------------------------------------------------------------------------
+-- Tests
+-- ---------------------------------------------------------------------------
+
+unsafeRight :: (Show e) => Either e a -> a
+unsafeRight (Right a) = a
+unsafeRight (Left e)  = error ("expected Right, got Left: " ++ show e)
+
+tests :: TestTree
+tests = testGroup "SSZ.Derive"
+  [ testGroup "fixed container (TestFixed)"
+      [ testCase "Ssz metadata: fixed-size 40 bytes" $ do
+          sszFixedSize @TestFixed @?= Just 40
+          sszIsFixedSize @TestFixed @?= True
+      , testCase "encode produces 40 bytes" $ do
+          let root = unsafeRight $ mkBytesN @32 (BS.replicate 32 0xAA)
+              tf = TestFixed 42 root
+          BS.length (sszEncode tf) @?= 40
+      , testCase "roundtrip" $ do
+          let root = unsafeRight $ mkBytesN @32 (BS.pack [1..32])
+              tf = TestFixed 12345 root
+          sszDecode (sszEncode tf) @?= Right tf
+      , testCase "hashTreeRoot matches manual computation" $ do
+          let root = unsafeRight $ mkBytesN @32 (BS.replicate 32 0)
+              tf = TestFixed 0 root
+              -- Field 0: hashTreeRoot(Word64 0) = 32 zero bytes
+              -- Field 1: hashTreeRoot(Bytes32 zero) = 32 zero bytes
+              -- merkleize([zero, zero], 2) = sha256(zero ++ zero)
+              fieldRoot0 = hashTreeRoot (0 :: Word64)
+              fieldRoot1 = hashTreeRoot root
+              expected = merkleize [fieldRoot0, fieldRoot1] 2
+          hashTreeRoot tf @?= expected
+      ]
+  , testGroup "mixed container (TestMixed)"
+      [ testCase "Ssz metadata: variable-size" $ do
+          sszIsFixedSize @TestMixed @?= False
+          sszFixedSize @TestMixed @?= Nothing
+      , testCase "roundtrip with non-empty list" $ do
+          let items = unsafeRight $ mkSszList @100 ([10, 20, 30] :: [Word64])
+              tm = TestMixed 99 items True
+          sszDecode (sszEncode tm) @?= Right tm
+      , testCase "roundtrip with empty list" $ do
+          let items = unsafeRight $ mkSszList @100 ([] :: [Word64])
+              tm = TestMixed 0 items False
+          sszDecode (sszEncode tm) @?= Right tm
+      ]
+  , testGroup "nested container (TestNested)"
+      [ testCase "roundtrip" $ do
+          let root = unsafeRight $ mkBytesN @32 (BS.pack [1..32])
+              inner = TestFixed 777 root
+              tn = TestNested inner 888
+          sszDecode (sszEncode tn) @?= Right tn
+      , testCase "hashTreeRoot" $ do
+          let root = unsafeRight $ mkBytesN @32 (BS.replicate 32 0xFF)
+              inner = TestFixed 1 root
+              tn = TestNested inner 2
+              innerRoot = hashTreeRoot inner
+              valueRoot = hashTreeRoot (2 :: Word64)
+              expected = merkleize [innerRoot, valueRoot] 2
+          hashTreeRoot tn @?= expected
+      ]
+  ]

--- a/test/Test/SSZ/List.hs
+++ b/test/Test/SSZ/List.hs
@@ -1,0 +1,60 @@
+module Test.SSZ.List (tests) where
+
+import qualified Data.ByteString as BS
+import Data.Word (Word64)
+import Test.Tasty
+import Test.Tasty.HUnit
+import Test.Tasty.QuickCheck
+import SSZ.Common
+import SSZ.List
+
+-- | Helper: unwrap a Right or fail the test.
+unsafeRight :: (Show e) => Either e a -> a
+unsafeRight (Right a) = a
+unsafeRight (Left e)  = error ("expected Right, got Left: " ++ show e)
+
+tests :: TestTree
+tests = testGroup "SSZ.List"
+  [ testGroup "mkSszList"
+      [ testCase "accepts within capacity" $ do
+          case mkSszList @10 ([1, 2, 3] :: [Word64]) of
+            Right _  -> pure ()
+            Left err -> assertFailure (show err)
+      , testCase "rejects exceeding capacity" $ do
+          case mkSszList @2 ([1, 2, 3] :: [Word64]) of
+            Left (InvalidLength 2 3) -> pure ()
+            other -> assertFailure ("expected InvalidLength 2 3, got " ++ show other)
+      , testCase "accepts empty list" $ do
+          case mkSszList @10 ([] :: [Word64]) of
+            Right l  -> unSszList l @?= []
+            Left err -> assertFailure (show err)
+      ]
+  , testGroup "Ssz metadata"
+      [ testCase "SszList is variable-size" $
+          sszIsFixedSize @(SszList 10 Word64) @?= False
+      ]
+  , testGroup "encode/decode fixed-size elements"
+      [ testCase "encode [1,2,3] as Word64" $ do
+          let l = unsafeRight $ mkSszList @10 ([1, 2, 3] :: [Word64])
+          BS.length (sszEncode l) @?= 24  -- 3 * 8 bytes
+      , testCase "roundtrip [42, 0, 999]" $ do
+          let l = unsafeRight $ mkSszList @100 ([42, 0, 999] :: [Word64])
+          fmap unSszList (sszDecode @(SszList 100 Word64) (sszEncode l)) @?= Right [42, 0, 999]
+      , testCase "roundtrip empty list" $ do
+          let l = unsafeRight $ mkSszList @10 ([] :: [Word64])
+          fmap unSszList (sszDecode @(SszList 10 Word64) (sszEncode l)) @?= Right []
+      , testCase "decode rejects exceeding capacity" $ do
+          let l = unsafeRight $ mkSszList @10 ([1, 2, 3, 4, 5] :: [Word64])
+              decoded = sszDecode @(SszList 3 Word64) (sszEncode l)
+          case decoded of
+            Left (InvalidLength 3 5) -> pure ()
+            other -> assertFailure ("expected InvalidLength 3 5, got " ++ show other)
+      ]
+  , testGroup "roundtrip properties"
+      [ testProperty "Word64 list roundtrip" $ \(xs :: [Word64]) ->
+          let capped = take 50 xs
+          in  case mkSszList @100 capped of
+                Right l  -> fmap unSszList (sszDecode @(SszList 100 Word64) (sszEncode l)) == Right capped
+                Left _   -> False
+      ]
+  ]

--- a/test/Test/SSZ/Merkleization.hs
+++ b/test/Test/SSZ/Merkleization.hs
@@ -1,0 +1,98 @@
+module Test.SSZ.Merkleization (tests) where
+
+import Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
+import qualified Data.Vector as V
+import Data.Word (Word64)
+import Test.Tasty
+import Test.Tasty.HUnit
+import SSZ.Common
+import SSZ.Merkleization
+
+-- | Helper to convert hex string to ByteString.
+hexToBS :: String -> ByteString
+hexToBS = BS.pack . go
+  where
+    go [] = []
+    go (a:b:rest) = fromIntegral (hexDigit a * 16 + hexDigit b) : go rest
+    go _ = error "hexToBS: odd length"
+    hexDigit c
+      | c >= '0' && c <= '9' = fromEnum c - fromEnum '0'
+      | c >= 'a' && c <= 'f' = fromEnum c - fromEnum 'a' + 10
+      | c >= 'A' && c <= 'F' = fromEnum c - fromEnum 'A' + 10
+      | otherwise = error ("hexToBS: invalid char " ++ [c])
+
+-- | Access a pre-computed zero hash by depth.
+zeroHash :: Int -> ByteString
+zeroHash i = SSZ.Merkleization.zeroHashes V.! i
+
+tests :: TestTree
+tests = testGroup "SSZ.Merkleization"
+  [ testGroup "sha256"
+      [ testCase "sha256 empty string matches NIST vector" $
+          sha256 BS.empty @?=
+            hexToBS "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      , testCase "sha256 \"abc\" matches NIST vector" $
+          sha256 (BS.pack [0x61, 0x62, 0x63]) @?=
+            hexToBS "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+      , testCase "sha256Pair a b == sha256 (a <> b)" $ do
+          let a = BS.pack [1, 2, 3]
+              b = BS.pack [4, 5, 6]
+          sha256Pair a b @?= sha256 (a <> b)
+      ]
+  , testGroup "pack"
+      [ testCase "empty input produces one zero chunk" $ do
+          let chunks = pack []
+          length chunks @?= 1
+          head chunks @?= BS.replicate 32 0
+      , testCase "32 bytes produces one chunk" $ do
+          let input = BS.replicate 32 0xAB
+              chunks = pack [input]
+          length chunks @?= 1
+          head chunks @?= input
+      , testCase "48 bytes produces two chunks (padded)" $ do
+          let input = BS.replicate 48 0xCD
+              chunks = pack [input]
+          length chunks @?= 2
+          (chunks !! 0) @?= BS.replicate 32 0xCD
+          (chunks !! 1) @?= (BS.replicate 16 0xCD <> BS.replicate 16 0)
+      ]
+  , testGroup "merkleize"
+      [ testCase "single chunk limit=1 is identity" $ do
+          let chunk = sha256 (BS.pack [42])
+          merkleize [chunk] 1 @?= chunk
+      , testCase "single chunk limit=2 pads with zero hash" $ do
+          let chunk = BS.replicate 32 0xAA
+              expected = sha256Pair chunk (zeroHash 0)
+          merkleize [chunk] 2 @?= expected
+      , testCase "two chunks limit=2 hashes pair" $ do
+          let c0 = BS.replicate 32 0x11
+              c1 = BS.replicate 32 0x22
+          merkleize [c0, c1] 2 @?= sha256Pair c0 c1
+      , testCase "single chunk limit=4 builds depth-2 tree" $ do
+          let chunk = BS.replicate 32 0xBB
+              z0 = zeroHash 0
+              z1 = zeroHash 1
+              left = sha256Pair chunk z0
+              expected = sha256Pair left z1
+          merkleize [chunk] 4 @?= expected
+      ]
+  , testGroup "mixInLength"
+      [ testCase "mixes root with length" $ do
+          let root = BS.replicate 32 0
+              expected = sha256Pair root (sszEncode (3 :: Word64))
+          mixInLength root 3 @?= expected
+      ]
+  , testGroup "hashTreeRoot"
+      [ testCase "Word64 0 hash tree root" $ do
+          hashTreeRoot (0 :: Word64) @?= BS.replicate 32 0
+      , testCase "Bytes32 is identity" $ do
+          let bs = BS.pack [1..32]
+          case mkBytesN @32 bs of
+            Right b32 -> hashTreeRoot b32 @?= bs
+            Left err  -> assertFailure (show err)
+      , testCase "Bool True hash tree root" $ do
+          let expected = BS.singleton 1 <> BS.replicate 31 0
+          hashTreeRoot True @?= expected
+      ]
+  ]

--- a/test/Test/SSZ/Support.hs
+++ b/test/Test/SSZ/Support.hs
@@ -1,0 +1,63 @@
+module Test.SSZ.Support
+  ( ArbWord8 (..)
+  , ArbWord16 (..)
+  , ArbWord32 (..)
+  , ArbWord64 (..)
+  , ArbBool (..)
+  , ArbBytesN (..)
+  , roundtripProp
+  ) where
+
+import qualified Data.ByteString as BS
+import Data.Proxy (Proxy (..))
+import Data.Word (Word8, Word16, Word32, Word64)
+import GHC.TypeNats (KnownNat, Nat, natVal)
+import SSZ.Common (BytesN, SszDecode (..), SszEncode (..), mkBytesN)
+import Test.QuickCheck (Arbitrary (..), Property, counterexample, (===), vectorOf, choose)
+
+newtype ArbWord8 = ArbWord8 Word8
+  deriving stock (Show, Eq)
+
+instance Arbitrary ArbWord8 where
+  arbitrary = ArbWord8 <$> arbitrary
+
+newtype ArbWord16 = ArbWord16 Word16
+  deriving stock (Show, Eq)
+
+instance Arbitrary ArbWord16 where
+  arbitrary = ArbWord16 <$> arbitrary
+
+newtype ArbWord32 = ArbWord32 Word32
+  deriving stock (Show, Eq)
+
+instance Arbitrary ArbWord32 where
+  arbitrary = ArbWord32 <$> arbitrary
+
+newtype ArbWord64 = ArbWord64 Word64
+  deriving stock (Show, Eq)
+
+instance Arbitrary ArbWord64 where
+  arbitrary = ArbWord64 <$> arbitrary
+
+newtype ArbBool = ArbBool Bool
+  deriving stock (Show, Eq)
+
+instance Arbitrary ArbBool where
+  arbitrary = ArbBool <$> arbitrary
+
+newtype ArbBytesN (n :: Nat) = ArbBytesN (BytesN n)
+  deriving stock (Show, Eq)
+
+instance KnownNat n => Arbitrary (ArbBytesN n) where
+  arbitrary = do
+    let len = fromIntegral (natVal (Proxy @n))
+    bytes <- BS.pack <$> vectorOf len (choose (0, 255))
+    case mkBytesN bytes of
+      Right bn -> pure (ArbBytesN bn)
+      Left _   -> error "ArbBytesN: impossible — length mismatch"
+
+-- | Property that checks SSZ roundtrip: decode . encode == identity.
+roundtripProp :: (SszEncode a, SszDecode a, Eq a, Show a) => a -> Property
+roundtripProp x =
+  counterexample ("encoded: " <> show (sszEncode x)) $
+    sszDecode (sszEncode x) === Right x

--- a/test/Test/SSZ/Vector.hs
+++ b/test/Test/SSZ/Vector.hs
@@ -1,0 +1,48 @@
+module Test.SSZ.Vector (tests) where
+
+import qualified Data.ByteString as BS
+import qualified Data.Vector as V
+import Data.Word (Word64)
+import Test.Tasty
+import Test.Tasty.HUnit
+import SSZ.Common
+import SSZ.Vector
+
+-- | Helper: unwrap a Right or fail the test.
+unsafeRight :: (Show e) => Either e a -> a
+unsafeRight (Right a) = a
+unsafeRight (Left e)  = error ("expected Right, got Left: " ++ show e)
+
+tests :: TestTree
+tests = testGroup "SSZ.Vector"
+  [ testGroup "mkSszVector"
+      [ testCase "accepts correct length" $ do
+          case mkSszVector @4 (V.fromList ([1, 2, 3, 4] :: [Word64])) of
+            Right _  -> pure ()
+            Left err -> assertFailure (show err)
+      , testCase "rejects wrong length" $ do
+          case mkSszVector @4 (V.fromList ([1, 2, 3] :: [Word64])) of
+            Left (InvalidLength 4 3) -> pure ()
+            other -> assertFailure ("expected InvalidLength 4 3, got " ++ show other)
+      ]
+  , testGroup "Ssz metadata"
+      [ testCase "SszVector 4 Word64 is fixed-size" $
+          sszIsFixedSize @(SszVector 4 Word64) @?= True
+      , testCase "SszVector 4 Word64 fixed size == 32" $
+          sszFixedSize @(SszVector 4 Word64) @?= Just 32
+      ]
+  , testGroup "encode/decode"
+      [ testCase "encode 4 Word64s" $ do
+          let v = unsafeRight $ mkSszVector @4 (V.fromList ([1, 2, 3, 4] :: [Word64]))
+          BS.length (sszEncode v) @?= 32
+      , testCase "roundtrip 4 Word64s" $ do
+          let v = unsafeRight $ mkSszVector @4 (V.fromList ([42, 0, 999, 1] :: [Word64]))
+              decoded = sszDecode @(SszVector 4 Word64) (sszEncode v)
+          fmap (V.toList . unSszVector) decoded @?= Right [42, 0, 999, 1]
+      , testCase "decode rejects wrong length" $ do
+          let decoded = sszDecode @(SszVector 4 Word64) (BS.replicate 16 0)
+          case decoded of
+            Left (InvalidLength 32 16) -> pure ()
+            other -> assertFailure ("expected InvalidLength 32 16, got " ++ show other)
+      ]
+  ]


### PR DESCRIPTION
## Summary

- **SSZ composite types**: `SszList`, `SszVector`, `Bitvector`, `Bitlist` with hidden constructors and smart constructors enforcing invariants (#18)
- **SSZ Merkleization**: SHA-256 via crypton, `pack`/`merkleize`/`mixInLength`/`hashTreeRoot` for all SSZ types, pre-computed zero hashes (#19)
- **SSZ auto-derivation**: GHC.Generics-based `genericSszEncode`/`Decode`/`FixedSize`/`HashTreeRoot` for container types (#20)
- **Consensus types**: `Checkpoint`, `AttestationData`, `SignedAttestation`, `BeaconBlock`, `BeaconState`, `Validator`, and all supporting types with derived SSZ instances (#21)
- **SSZ Container helpers**: two-pass encoder/decoder shared by manual and Generic instances
- **Consensus constants**: slot timing, finality params, type-level collection limits, crypto sizes

Closes #14, closes #15, closes #16, closes #17, closes #18, closes #19, closes #20, closes #21, closes #47

## Test plan

- [x] 99 tests passing (`cabal test`)
- [x] SSZ roundtrip property tests for all primitive types (Word8/16/32/64, Bool, BytesN)
- [x] SSZ roundtrip tests for composite types (SszList, SszVector, Bitvector, Bitlist)
- [x] Merkleization: SHA-256 NIST vectors, pack/merkleize with various limits, hashTreeRoot
- [x] Generic derivation: fixed containers, mixed fixed/variable, nested containers
- [x] Consensus types: metadata assertions, roundtrip for Checkpoint/AttestationData/SignedAttestation/BeaconBlockHeader/Validator
- [x] hashTreeRoot verified for Checkpoint, BeaconBlockHeader
- [x] Smart constructor rejection tests (wrong length, exceeding capacity, invalid sentinel)
- [x] Build passes with `-Werror` (zero warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)