### PR TITLE
fix: enable test dependencies in CI solver plan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
         run: cabal update
 
       - name: Build dependencies
-        run: cabal build --only-dependencies
+        run: cabal build --only-dependencies --enable-tests
 
       - name: Build
         run: cabal build

--- a/cabal.project
+++ b/cabal.project
@@ -1,1 +1,2 @@
 packages: .
+tests: True


### PR DESCRIPTION
## Summary
- Add `tests: True` to `cabal.project` so the dependency solver always considers test suite dependencies
- Add `--enable-tests` to `cabal build --only-dependencies` in CI workflow

This fixes Cabal-7043 errors on all open PRs (#62-#66) where `cabal test` fails because the solver picked a plan without test suite dependencies.

## Test plan
- [ ] Verify this PR's CI passes
- [ ] Merge, then rebase/merge main into #62-#66 to fix their CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)