### PR TITLE
feat: implement validator actor and P2P IPC sidecar backend (Phase 6A/6B)

### DIFF
--- a/app/Options.hs
+++ b/app/Options.hs
@@ -19,6 +19,7 @@ data Options = Options
   , optRpcPort         :: !(Maybe Int)
   , optMetricsPort     :: !(Maybe Int)
   , optValidatorKeyDir :: !(Maybe FilePath)
+  , optP2PSocket       :: !(Maybe FilePath)
   , optLogLevel        :: !LogLevel
   } deriving stock (Show)
 
@@ -84,6 +85,11 @@ optionsParser = Options
      <> metavar "DIR"
      <> help "Validator key directory (enables validator mode)"
       ))
+  <*> optional (strOption
+      ( long "p2p-socket"
+     <> metavar "PATH"
+     <> help "Unix socket path for P2P IPC sidecar"
+      ))
   <*> option auto
       ( long "log-level"
      <> metavar "LEVEL"
@@ -104,5 +110,6 @@ toNodeConfig o = NodeConfig
   , ncRpcPort         = optRpcPort o
   , ncMetricsPort     = optMetricsPort o
   , ncValidatorKeyDir = optValidatorKeyDir o
+  , ncP2PSocket       = optP2PSocket o
   , ncLogLevel        = optLogLevel o
   }

--- a/docs/dev/07-p2p-ipc-protocol.md
+++ b/docs/dev/07-p2p-ipc-protocol.md
@@ -1,0 +1,163 @@
+---
+title: P2P IPC Sidecar Protocol
+last_updated: 2026-03-17
+tags:
+  - p2p
+  - ipc
+  - networking
+---
+
+# P2P IPC Sidecar Protocol
+
+## Overview
+
+The Haskell consensus client communicates with a libp2p sidecar process via
+JSON-RPC 2.0 over a Unix domain socket. This architecture separates networking
+concerns (gossipsub, QUIC transport, discv5 discovery) from consensus logic.
+
+## Transport
+
+- **Socket**: Unix domain socket at a configurable path (default: `$DATA_DIR/p2p.sock`)
+- **Framing**: newline-delimited JSON (one JSON object per line)
+- **Encoding**: UTF-8
+
+## JSON-RPC 2.0 Messages
+
+### Haskell → Sidecar (Requests)
+
+#### `publish`
+
+Publish a message to a gossipsub topic.
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "publish",
+  "params": [{"topic": "beacon_block", "data": "cafebabe..."}],
+  "id": 1
+}
+```
+
+Response: `{"jsonrpc": "2.0", "result": null, "id": 1}`
+
+#### `subscribe`
+
+Subscribe to a gossipsub topic. Incoming messages arrive as `message` notifications.
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "subscribe",
+  "params": [{"topic": "attestation_0"}],
+  "id": 2
+}
+```
+
+#### `unsubscribe`
+
+Unsubscribe from a gossipsub topic.
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "unsubscribe",
+  "params": [{"topic": "attestation_0"}],
+  "id": 3
+}
+```
+
+#### `request_by_range`
+
+Request blocks by slot range (for initial sync).
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "request_by_range",
+  "params": [{"start": 0, "count": 10}],
+  "id": 4
+}
+```
+
+Response: `{"jsonrpc": "2.0", "result": ["cafebabe...", "deadbeef..."], "id": 4}`
+
+#### `request_by_root`
+
+Request blocks by root hashes.
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "request_by_root",
+  "params": [{"roots": ["aabb...", "ccdd..."]}],
+  "id": 5
+}
+```
+
+#### `peer_count`
+
+Get the current number of connected peers.
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "peer_count",
+  "params": [],
+  "id": 6
+}
+```
+
+Response: `{"jsonrpc": "2.0", "result": 42, "id": 6}`
+
+#### `stop`
+
+Gracefully shut down the sidecar.
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "stop",
+  "params": [],
+  "id": 7
+}
+```
+
+### Sidecar → Haskell (Notifications)
+
+#### `message`
+
+A gossipsub message received on a subscribed topic.
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "message",
+  "params": {"topic": "beacon_block", "data": "cafebabe..."}
+}
+```
+
+Note: notifications have no `id` field.
+
+## Topics
+
+| Topic | Description |
+|-------|-------------|
+| `attestation_0` .. `attestation_3` | Per-subnet attestation gossip |
+| `aggregation` | Aggregated attestation proofs |
+| `beacon_block` | New beacon blocks |
+
+## Data Encoding
+
+All `data` fields use hex-encoded SSZ+zlib-compressed bytes. The Haskell client
+encodes via `Network.P2P.Wire.encodeWire` and decodes via `decodeWire`.
+
+## Sidecar Implementation
+
+The sidecar is a standalone Rust binary using `rust-libp2p` with:
+
+- QUIC transport
+- Gossipsub protocol
+- discv5 peer discovery
+- Unix domain socket JSON-RPC server
+
+See `p2p-sidecar/` for the implementation (when available).

--- a/lean-consensus.cabal
+++ b/lean-consensus.cabal
@@ -51,6 +51,7 @@ library
         Consensus.StateTransition
         Consensus.ForkChoice
         Network.P2P.Types
+        Network.P2P.IPC
         Network.P2P.Wire
         Network.MessageHandler
         Network.Sync
@@ -59,6 +60,8 @@ library
         Config
         Genesis
         Actor
+        NodeTypes
+        Validator
         Node
         Network.RPC
         Metrics
@@ -78,6 +81,7 @@ library
       , rocksdb-haskell-jprupp >= 2.1 && < 2.2
       , aeson         >= 2.1   && < 2.3
       , base16-bytestring >= 1.0 && < 1.1
+      , network       >= 3.1   && < 3.3
       , warp          >= 3.3   && < 3.5
       , wai           >= 3.2   && < 3.3
       , http-types    >= 0.12  && < 0.13
@@ -139,6 +143,7 @@ test-suite lean-consensus-test
         Test.Network.P2PTypes
         Test.Network.Wire
         Test.Network.MessageHandler
+        Test.Network.IPC
         Test.Network.Sync
         Test.Network.Aggregator
         Test.Network.Integration
@@ -146,6 +151,7 @@ test-suite lean-consensus-test
         Test.Genesis
         Test.Actor
         Test.Node
+        Test.Validator
         Test.Network.RPC
         Test.Metrics
         Test.Integration.Devnet
@@ -167,5 +173,7 @@ test-suite lean-consensus-test
       , stm             >= 2.5  && < 2.6
       , aeson           >= 2.1  && < 2.3
       , text            >= 2.0  && < 2.2
+      , network         >= 3.1  && < 3.3
+      , base16-bytestring >= 1.0 && < 1.1
       , wai             >= 3.2  && < 3.3
       , http-types      >= 0.12 && < 0.13

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -20,6 +20,7 @@ data NodeConfig = NodeConfig
   , ncRpcPort         :: !(Maybe Int)
   , ncMetricsPort     :: !(Maybe Int)
   , ncValidatorKeyDir :: !(Maybe FilePath)
+  , ncP2PSocket       :: !(Maybe FilePath)
   , ncLogLevel        :: !LogLevel
   } deriving stock (Eq, Show)
 
@@ -35,5 +36,6 @@ defaultNodeConfig = NodeConfig
   , ncRpcPort         = Nothing
   , ncMetricsPort     = Nothing
   , ncValidatorKeyDir = Nothing
+  , ncP2PSocket       = Nothing
   , ncLogLevel        = Info
   }

--- a/src/Network/P2P/IPC.hs
+++ b/src/Network/P2P/IPC.hs
@@ -1,0 +1,231 @@
+-- | IPC-based P2P backend: communicates with a libp2p sidecar process
+-- via JSON-RPC 2.0 over a Unix domain socket.
+module Network.P2P.IPC
+  ( connectIPC
+  , IPCHandle
+  , ipcP2PHandle
+  ) where
+
+import Control.Concurrent (forkIO, ThreadId)
+import Control.Concurrent.MVar (MVar, modifyMVar_, readMVar, newEmptyMVar, putMVar, takeMVar, newMVar)
+import Control.Exception (SomeException, catch)
+import Data.Aeson ((.=), (.:))
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Types as Aeson
+import Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Base16 as Base16
+import qualified Data.ByteString.Lazy as LBS
+import Data.IORef (IORef, newIORef, atomicModifyIORef')
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import Data.Text (Text)
+import Data.Text.Encoding (encodeUtf8, decodeUtf8)
+import Network.Socket
+    ( Socket, SockAddr (..)
+    , socket, connect, close
+    , Family (..), SocketType (..)
+    , defaultProtocol
+    )
+import Network.Socket.ByteString (sendAll, recv)
+
+import Network.P2P.Types (P2PHandle (..), topicString)
+import SSZ.Common (unBytesN)
+
+-- | Handle to the IPC connection with the P2P sidecar.
+data IPCHandle = IPCHandle
+  { ipcSocket       :: !Socket
+  , ipcNextId       :: !(IORef Int)
+  , ipcCallbacks    :: !(MVar (Map String (ByteString -> IO ())))
+  , ipcPendingCalls :: !(MVar (Map Int (MVar Aeson.Value)))
+  , ipcReaderThread :: !ThreadId
+  }
+
+-- | Connect to a P2P sidecar via Unix domain socket.
+connectIPC :: FilePath -> IO IPCHandle
+connectIPC socketPath = do
+  sock <- socket AF_UNIX Stream defaultProtocol
+  connect sock (SockAddrUnix socketPath)
+  nextId <- newIORef 1
+  callbacks <- newMVar Map.empty
+  pending <- newMVar Map.empty
+  tid <- forkIO (readerLoop sock callbacks pending)
+  pure IPCHandle
+    { ipcSocket       = sock
+    , ipcNextId       = nextId
+    , ipcCallbacks    = callbacks
+    , ipcPendingCalls = pending
+    , ipcReaderThread = tid
+    }
+
+-- | Build a P2PHandle from an IPC connection.
+ipcP2PHandle :: IPCHandle -> P2PHandle
+ipcP2PHandle ipc = P2PHandle
+  { p2hPublish = \topic msg -> do
+      let topicStr = topicString topic
+          dataHex = decodeUtf8 (Base16.encode msg)
+      _ <- rpcCall ipc "publish"
+        [Aeson.object ["topic" .= topicStr, "data" .= dataHex]]
+      pure ()
+
+  , p2hSubscribe = \topic callback -> do
+      let topicStr = topicString topic
+      modifyMVar_ (ipcCallbacks ipc) $ \m ->
+        pure (Map.insert topicStr callback m)
+      _ <- rpcCall ipc "subscribe"
+        [Aeson.object ["topic" .= topicStr]]
+      pure ()
+
+  , p2hUnsubscribe = \topic -> do
+      let topicStr = topicString topic
+      modifyMVar_ (ipcCallbacks ipc) $ \m ->
+        pure (Map.delete topicStr m)
+      _ <- rpcCall ipc "unsubscribe"
+        [Aeson.object ["topic" .= topicStr]]
+      pure ()
+
+  , p2hRequestByRange = \startSlot count -> do
+      result <- rpcCall ipc "request_by_range"
+        [Aeson.object ["start" .= startSlot, "count" .= count]]
+      case Aeson.parseMaybe parseBlockList result of
+        Just blocks -> pure blocks
+        Nothing     -> pure []
+
+  , p2hRequestByRoot = \roots -> do
+      let rootHexes = map (decodeUtf8 . Base16.encode . unBytesN) roots
+      result <- rpcCall ipc "request_by_root"
+        [Aeson.object ["roots" .= rootHexes]]
+      case Aeson.parseMaybe parseBlockList result of
+        Just blocks -> pure blocks
+        Nothing     -> pure []
+
+  , p2hPeerCount = do
+      result <- rpcCall ipc "peer_count" []
+      case Aeson.parseMaybe (.: "count") =<< asObject result of
+        Just n  -> pure n
+        Nothing -> case Aeson.parseMaybe Aeson.parseJSON result of
+          Just n  -> pure (n :: Int)
+          Nothing -> pure 0
+
+  , p2hLocalPeerId = do
+      result <- rpcCall ipc "local_peer_id" []
+      case Aeson.parseMaybe Aeson.parseJSON result of
+        Just s  -> pure (s :: String)
+        Nothing -> pure ""
+
+  , p2hStop = do
+      _ <- rpcCall ipc "stop" []
+      close (ipcSocket ipc)
+  }
+
+-- ---------------------------------------------------------------------------
+-- JSON-RPC internals
+-- ---------------------------------------------------------------------------
+
+-- | Make a JSON-RPC 2.0 call and wait for the response.
+rpcCall :: IPCHandle -> Text -> [Aeson.Value] -> IO Aeson.Value
+rpcCall ipc method params = do
+  reqId <- atomicModifyIORef' (ipcNextId ipc) (\n -> (n + 1, n))
+  responseMVar <- newEmptyMVar
+
+  modifyMVar_ (ipcPendingCalls ipc) $ \m ->
+    pure (Map.insert reqId responseMVar m)
+
+  let request = Aeson.object
+        [ "jsonrpc" .= ("2.0" :: Text)
+        , "method"  .= method
+        , "params"  .= params
+        , "id"      .= reqId
+        ]
+      encoded = LBS.toStrict (Aeson.encode request) <> "\n"
+
+  sendAll (ipcSocket ipc) encoded
+  takeMVar responseMVar
+
+-- | Background reader thread: dispatches responses and notifications.
+readerLoop :: Socket -> MVar (Map String (ByteString -> IO ())) -> MVar (Map Int (MVar Aeson.Value)) -> IO ()
+readerLoop sock callbacks pending = go BS.empty
+  where
+    go buffer = do
+      chunk <- recv sock 4096 `catch` (\(_ :: SomeException) -> pure BS.empty)
+      if BS.null chunk
+        then pure ()  -- Connection closed
+        else do
+          let combined = buffer <> chunk
+          rest <- processLines combined
+          go rest
+
+    processLines bs =
+      case BS.elemIndex 0x0A bs of  -- newline
+        Nothing -> pure bs
+        Just idx -> do
+          let (line, remaining) = BS.splitAt idx bs
+              rest = BS.drop 1 remaining  -- skip the newline
+          handleLine line callbacks pending
+          processLines rest
+
+-- | Handle a single JSON-RPC line (response or notification).
+handleLine :: ByteString -> MVar (Map String (ByteString -> IO ())) -> MVar (Map Int (MVar Aeson.Value)) -> IO ()
+handleLine line callbacks pending =
+  case Aeson.decodeStrict line of
+    Nothing -> pure ()
+    Just val -> case val of
+      Aeson.Object obj -> do
+        -- Check if it's a response (has "id" field)
+        case Aeson.parseMaybe (.: "id") obj of
+          Just (reqId :: Int) -> do
+            let result = case Aeson.parseMaybe (.: "result") obj of
+                  Just r  -> r
+                  Nothing -> Aeson.Null
+            pendingMap <- readMVar pending
+            case Map.lookup reqId pendingMap of
+              Just mvar -> do
+                putMVar mvar result
+                modifyMVar_ pending $ pure . Map.delete reqId
+              Nothing -> pure ()
+
+          Nothing -> do
+            -- It's a notification — check for "method" == "message"
+            case Aeson.parseMaybe (.: "method") obj of
+              Just ("message" :: Text) -> do
+                let mParams = Aeson.parseMaybe (.: "params") obj
+                case mParams of
+                  Just paramObj -> handleNotification paramObj callbacks
+                  Nothing -> pure ()
+              _ -> pure ()
+
+      _ -> pure ()
+
+-- | Handle a "message" notification from the sidecar.
+handleNotification :: Aeson.Object -> MVar (Map String (ByteString -> IO ())) -> IO ()
+handleNotification params callbacks = do
+  let mTopic = Aeson.parseMaybe (.: "topic") params
+      mData  = Aeson.parseMaybe (.: "data") params
+  case (mTopic, mData) of
+    (Just topic, Just dataHex) -> do
+      case Base16.decode (encodeUtf8 (dataHex :: Text)) of
+        Left _ -> pure ()
+        Right bs -> do
+          cbs <- readMVar callbacks
+          case Map.lookup (topic :: String) cbs of
+            Just cb -> cb bs `catch` (\(_ :: SomeException) -> pure ())
+            Nothing -> pure ()
+    _ -> pure ()
+
+-- ---------------------------------------------------------------------------
+-- Helpers
+-- ---------------------------------------------------------------------------
+
+parseBlockList :: Aeson.Value -> Aeson.Parser [ByteString]
+parseBlockList = Aeson.withArray "blocks" $ \arr ->
+  mapM parseHexBlock (map id (foldr (:) [] arr))
+
+parseHexBlock :: Aeson.Value -> Aeson.Parser ByteString
+parseHexBlock = Aeson.withText "hex" $ \t ->
+  case Base16.decode (encodeUtf8 t) of
+    Left _   -> fail "invalid hex"
+    Right bs -> pure bs
+
+asObject :: Aeson.Value -> Maybe Aeson.Object
+asObject (Aeson.Object o) = Just o
+asObject _                = Nothing

--- a/src/Node.hs
+++ b/src/Node.hs
@@ -17,19 +17,23 @@ import Actor (Actor (..), spawnActor, send, waitActor)
 import Config (NodeConfig (..))
 import qualified Data.Map.Strict as Map
 import Consensus.Types
-  ( SignedBeaconBlock
-  , SignedAttestation
-  , SignedAggregatedAttestation (..)
+  ( SignedAggregatedAttestation (..)
   , Store (..)
   , BeaconState (..)
   , AttestationData (..)
   , LatestMessage (..)
   , Checkpoint (..)
+  , XmssPubkey
   )
 import Consensus.Constants (Root, Slot, ValidatorIndex)
 import Consensus.ForkChoice (onBlock, onAttestation)
 import Consensus.StateTransition (processSlots, expandAggregationBits)
-import Genesis (GenesisConfig)
+import Crypto.KeyManager (loadManagedKey, managedPublicKey)
+import Crypto.SigningRoot (computeDomain)
+import Genesis (GenesisConfig (..), GenesisValidator (..))
+import NodeTypes
+import SSZ.Common (mkBytesN, zeroN)
+import SSZ.Merkleization (SszHashTreeRoot (..))
 import Storage
   ( StorageHandle
   , readCurrentState
@@ -38,28 +42,7 @@ import Storage
   , writeForkChoiceStore
   , putBlock
   )
-import SSZ.Common (mkBytesN)
-import SSZ.Merkleization (SszHashTreeRoot (..))
-
--- | Messages for the blockchain (fork-choice) actor.
-data BlockchainMsg
-  = BcSlotTick !Slot
-  | BcNewBlock !SignedBeaconBlock
-  | BcNewAttestation !SignedAttestation
-  | BcNewAggregation !SignedAggregatedAttestation
-  | BcShutdown
-
--- | Messages for the P2P networking actor.
-data P2PMsg
-  = P2PPublishBlock !SignedBeaconBlock
-  | P2PPublishAttestation !SignedAttestation
-  | P2PPublishAggregation !SignedAggregatedAttestation
-  | P2PShutdown
-
--- | Messages for the validator duty actor.
-data ValidatorMsg
-  = ValSlotTick !Slot
-  | ValShutdown
+import Validator (ValidatorEnv (..), validatorLoop)
 
 -- | Collection of all running node actors.
 data NodeActors = NodeActors
@@ -74,12 +57,30 @@ startNode
   -> StorageHandle
   -> GenesisConfig
   -> IO NodeActors
-startNode config storageHandle _genesis = do
+startNode config storageHandle genesis = do
   bcActor <- spawnActor "blockchain" (blockchainLoop storageHandle)
   p2pActor <- spawnActor "p2p" p2pLoop
   valActor <- case ncValidatorKeyDir config of
     Nothing  -> pure Nothing
-    Just _   -> Just <$> spawnActor "validator" validatorLoop
+    Just keyDir -> do
+      let keyPath = keyDir <> "/validator.key"
+      mkResult <- loadManagedKey keyPath
+      case mkResult of
+        Left _err -> pure Nothing
+        Right managedKey -> do
+          pubKey <- managedPublicKey managedKey
+          let valIdx = findValidatorIndex genesis pubKey
+              domain = computeDomain (zeroN @4) (gcForkVersion genesis) (zeroN @32)
+              env = ValidatorEnv
+                { veStorage        = storageHandle
+                , veManagedKey     = managedKey
+                , veValidatorIndex = valIdx
+                , veDomain         = domain
+                , veKeyPersistPath = keyPath
+                , veBcActor        = bcActor
+                , veP2PActor       = p2pActor
+                }
+          Just <$> spawnActor "validator" (validatorLoop env)
   pure $ NodeActors bcActor p2pActor valActor
 
 -- | Stop all node actors gracefully by sending shutdown messages.
@@ -88,7 +89,6 @@ stopNode actors = do
   maybe (pure ()) (\v -> atomically $ send v ValShutdown) (naValidator actors)
   atomically $ send (naP2P actors) P2PShutdown
   atomically $ send (naBlockchain actors) BcShutdown
-  -- Wait for graceful completion
   maybe (pure ()) (void . waitActor) (naValidator actors)
   void $ waitActor (naP2P actors)
   void $ waitActor (naBlockchain actors)
@@ -151,7 +151,6 @@ blockchainLoop storage queue = go
           go
 
         BcNewAggregation agg -> do
-          -- Expand aggregation bits and apply each voter's attestation to fork choice
           store <- atomically $ readForkChoiceStore storage
           let ad = saaData agg
               subnetId = saaSubnetId agg
@@ -174,16 +173,6 @@ p2pLoop queue = go
         P2PPublishBlock _block -> go
         P2PPublishAttestation _att -> go
         P2PPublishAggregation _agg -> go
-
--- | Validator actor loop: responds to slot ticks with duty checks.
-validatorLoop :: TQueue ValidatorMsg -> IO ()
-validatorLoop queue = go
-  where
-    go = do
-      msg <- atomically $ readTQueue queue
-      case msg of
-        ValShutdown -> pure ()
-        ValSlotTick _slot -> go
 
 -- | Compute the SSZ hash tree root as a Bytes32 root.
 toRoot :: SszHashTreeRoot a => a -> Root
@@ -209,3 +198,13 @@ updateLatestMsg store vi slot root =
   in  if shouldUpdate
         then store { stLatestMessages = Map.insert vi msg (stLatestMessages store) }
         else store
+
+-- | Find a validator's index in the genesis config by matching public keys.
+findValidatorIndex :: GenesisConfig -> XmssPubkey -> ValidatorIndex
+findValidatorIndex gc pubKey =
+  case [ fromIntegral i :: ValidatorIndex
+       | (i, gv) <- zip [(0 :: Int)..] (gcValidators gc)
+       , gvPubkey gv == pubKey
+       ] of
+    (idx : _) -> idx
+    []        -> 0

--- a/src/NodeTypes.hs
+++ b/src/NodeTypes.hs
@@ -1,0 +1,34 @@
+-- | Shared message types for node actors.
+-- Separated from Node to avoid circular dependencies with Validator.
+module NodeTypes
+  ( BlockchainMsg (..)
+  , P2PMsg (..)
+  , ValidatorMsg (..)
+  ) where
+
+import Consensus.Constants (Slot)
+import Consensus.Types
+  ( SignedBeaconBlock
+  , SignedAttestation
+  , SignedAggregatedAttestation
+  )
+
+-- | Messages for the blockchain (fork-choice) actor.
+data BlockchainMsg
+  = BcSlotTick !Slot
+  | BcNewBlock !SignedBeaconBlock
+  | BcNewAttestation !SignedAttestation
+  | BcNewAggregation !SignedAggregatedAttestation
+  | BcShutdown
+
+-- | Messages for the P2P networking actor.
+data P2PMsg
+  = P2PPublishBlock !SignedBeaconBlock
+  | P2PPublishAttestation !SignedAttestation
+  | P2PPublishAggregation !SignedAggregatedAttestation
+  | P2PShutdown
+
+-- | Messages for the validator duty actor.
+data ValidatorMsg
+  = ValSlotTick !Slot
+  | ValShutdown

--- a/src/Validator.hs
+++ b/src/Validator.hs
@@ -1,0 +1,134 @@
+-- | Validator actor: proposes blocks and creates attestations based on slot duties.
+module Validator
+  ( ValidatorEnv (..)
+  , validatorLoop
+  ) where
+
+import Control.Concurrent.STM
+
+import Actor (Actor, send)
+import Consensus.Constants (Domain, Root, Slot, ValidatorIndex)
+import Consensus.ForkChoice (getHead)
+import Consensus.StateTransition (getProposerIndex, processSlots)
+import Consensus.Types
+    ( AttestationData (..)
+    , BeaconBlock (..)
+    , BeaconBlockBody (..)
+    , BeaconState (..)
+    , Checkpoint (..)
+    , SignedAggregatedAttestation (..)
+    , Store
+    )
+import Crypto.KeyManager (ManagedKey)
+import Crypto.Operations (signBlock, signAttestation)
+import NodeTypes (BlockchainMsg (..), P2PMsg (..), ValidatorMsg (..))
+import SSZ.Common (mkBytesN, zeroN)
+import SSZ.List (mkSszList, unSszList)
+import SSZ.Merkleization (SszHashTreeRoot (..))
+import Storage (StorageHandle, readCurrentState, readForkChoiceStore)
+
+-- | Environment for the validator actor.
+data ValidatorEnv = ValidatorEnv
+  { veStorage        :: !StorageHandle
+  , veManagedKey     :: !ManagedKey
+  , veValidatorIndex :: !ValidatorIndex
+  , veDomain         :: !Domain
+  , veKeyPersistPath :: !FilePath
+  , veBcActor        :: !(Actor BlockchainMsg)
+  , veP2PActor       :: !(Actor P2PMsg)
+  }
+
+-- | Validator actor loop: responds to slot ticks with proposal and attestation duties.
+validatorLoop :: ValidatorEnv -> TQueue ValidatorMsg -> IO ()
+validatorLoop env queue = go
+  where
+    go = do
+      msg <- atomically $ readTQueue queue
+      case msg of
+        ValShutdown -> pure ()
+        ValSlotTick slot -> do
+          handleSlotDuties env slot
+          go
+
+-- | Handle all validator duties for a given slot.
+handleSlotDuties :: ValidatorEnv -> Slot -> IO ()
+handleSlotDuties env slot = do
+  state <- atomically $ readCurrentState (veStorage env)
+  store <- atomically $ readForkChoiceStore (veStorage env)
+
+  -- Advance state to current slot for accurate duty checks
+  case processSlots state slot of
+    Left _err -> pure ()
+    Right currentState -> do
+      -- Check proposal duty
+      let expectedProposer = getProposerIndex currentState
+      if expectedProposer == veValidatorIndex env
+        then proposeBlock env currentState store slot
+        else pure ()
+
+      -- All validators attest every slot
+      createAttestation env currentState store slot
+
+-- | Propose a block for the current slot.
+proposeBlock :: ValidatorEnv -> BeaconState -> Store -> Slot -> IO ()
+proposeBlock env state _store slot = do
+  let parentRoot = toRoot (bsLatestBlockHeader state)
+      pendingAtts = unSszList (bsCurrentAttestations state)
+
+  -- Filter attestations: only include those from recent slots
+  let recentAtts = take 128 $ filter
+        (\saa -> adSlot (saaData saa) + 3 >= slot && adSlot (saaData saa) < slot)
+        pendingAtts
+
+  body <- case mkSszList @128 recentAtts of
+    Left _  -> pure $ BeaconBlockBody { bbbAttestations = forceRight $ mkSszList @128 [] }
+    Right attList -> pure $ BeaconBlockBody { bbbAttestations = attList }
+
+  let block = BeaconBlock
+        { bbSlot          = slot
+        , bbProposerIndex = veValidatorIndex env
+        , bbParentRoot    = parentRoot
+        , bbStateRoot     = zeroN @32
+        , bbBody          = body
+        }
+
+  result <- signBlock (veManagedKey env) (veKeyPersistPath env) block (veDomain env)
+  case result of
+    Left _err -> pure ()
+    Right signedBlock -> atomically $ do
+      send (veBcActor env) (BcNewBlock signedBlock)
+      send (veP2PActor env) (P2PPublishBlock signedBlock)
+
+-- | Create and sign an attestation for the current slot.
+createAttestation :: ValidatorEnv -> BeaconState -> Store -> Slot -> IO ()
+createAttestation env state store slot = do
+  let headRoot = getHead store
+      source = bsJustifiedCheckpoint state
+      target = Checkpoint slot headRoot
+
+      attData = AttestationData
+        { adSlot             = slot
+        , adHeadRoot         = headRoot
+        , adSourceCheckpoint = source
+        , adTargetCheckpoint = target
+        }
+
+  result <- signAttestation
+    (veManagedKey env) (veKeyPersistPath env) attData
+    (veValidatorIndex env) (veDomain env)
+
+  case result of
+    Left _err -> pure ()
+    Right signedAtt -> atomically $ do
+      send (veBcActor env) (BcNewAttestation signedAtt)
+      send (veP2PActor env) (P2PPublishAttestation signedAtt)
+
+-- | Compute the SSZ hash tree root as a Bytes32 root.
+toRoot :: SszHashTreeRoot a => a -> Root
+toRoot a = case mkBytesN @32 (hashTreeRoot a) of
+  Right r -> r
+  Left _  -> error "toRoot: hashTreeRoot did not produce 32 bytes"
+
+forceRight :: Either e a -> a
+forceRight (Right a) = a
+forceRight (Left _)  = error "forceRight: unexpected Left"

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -24,6 +24,7 @@ import qualified Test.Consensus.Integration as Integration
 import qualified Test.Network.P2PTypes as P2PTypes
 import qualified Test.Network.Wire as Wire
 import qualified Test.Network.MessageHandler as MessageHandler
+import qualified Test.Network.IPC as IPC
 import qualified Test.Network.Sync as Sync
 import qualified Test.Network.Aggregator as Aggregator
 import qualified Test.Network.Integration as NetworkIntegration
@@ -31,6 +32,7 @@ import qualified Test.Storage as Storage
 import qualified Test.Genesis as Genesis
 import qualified Test.Actor as Actor
 import qualified Test.Node as Node
+import qualified Test.Validator as Validator
 import qualified Test.Network.RPC as RPC
 import qualified Test.Metrics as Metrics
 import qualified Test.Integration.Devnet as Devnet
@@ -62,6 +64,7 @@ tests = testGroup "lean-consensus"
   , P2PTypes.tests
   , Wire.tests
   , MessageHandler.tests
+  , IPC.tests
   , Sync.tests
   , Aggregator.tests
   , NetworkIntegration.tests
@@ -69,6 +72,7 @@ tests = testGroup "lean-consensus"
   , Genesis.tests
   , Actor.tests
   , Node.tests
+  , Validator.tests
   , RPC.tests
   , Metrics.tests
   , Devnet.tests

--- a/test/Test/Network/IPC.hs
+++ b/test/Test/Network/IPC.hs
@@ -1,0 +1,158 @@
+module Test.Network.IPC (tests) where
+
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import Control.Concurrent (forkIO, threadDelay)
+import Control.Concurrent.MVar (newEmptyMVar, putMVar, takeMVar)
+import Control.Exception (SomeException, catch)
+import Data.Aeson ((.=))
+import qualified Data.Aeson as Aeson
+import Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Base16 as Base16
+import qualified Data.ByteString.Lazy as LBS
+import Data.IORef (newIORef, readIORef, modifyIORef')
+import Data.Text (Text)
+import Data.Text.Encoding (encodeUtf8, decodeUtf8)
+import Network.Socket
+    ( Socket, SockAddr (..)
+    , socket, bind, listen, accept, close
+    , Family (..), SocketType (..)
+    , defaultProtocol, maxListenQueue
+    )
+import Network.Socket.ByteString (sendAll, recv)
+import System.IO.Temp (withSystemTempDirectory)
+
+import Network.P2P.IPC (connectIPC, ipcP2PHandle)
+import Network.P2P.Types (P2PHandle (..), Topic (..))
+
+tests :: TestTree
+tests = testGroup "Network.P2P.IPC"
+  [ testCase "publish sends JSON-RPC request to sidecar" testPublish
+  , testCase "subscribe registers callback and receives notifications" testSubscribe
+  , testCase "peer_count returns value from sidecar" testPeerCount
+  ]
+
+-- | Run a mock sidecar server for the duration of a test.
+withMockSidecar
+  :: FilePath                          -- ^ socket path
+  -> (Socket -> ByteString -> IO ())   -- ^ handler: client socket, received data
+  -> IO a                             -- ^ test action (connect after server is ready)
+  -> IO a
+withMockSidecar sockPath handler action = do
+  serverSock <- socket AF_UNIX Stream defaultProtocol
+  bind serverSock (SockAddrUnix sockPath)
+  listen serverSock maxListenQueue
+
+  ready <- newEmptyMVar
+  _ <- forkIO $ do
+    putMVar ready ()
+    (clientSock, _) <- accept serverSock
+    let loop = do
+          bs <- recv clientSock 4096 `catch` (\(_ :: SomeException) -> pure BS.empty)
+          if BS.null bs
+            then close clientSock
+            else do
+              handler clientSock bs
+              loop
+    loop `catch` (\(_ :: SomeException) -> pure ())
+    close serverSock
+
+  takeMVar ready
+  threadDelay 10000  -- let server fully bind
+  action
+
+-- | Test that publish sends a proper JSON-RPC request.
+testPublish :: IO ()
+testPublish =
+  withSystemTempDirectory "lc-test-ipc" $ \tmpDir -> do
+    let sockPath = tmpDir <> "/test.sock"
+    received <- newIORef BS.empty
+
+    withMockSidecar sockPath
+      (\clientSock bs -> do
+        modifyIORef' received (<> bs)
+        -- Send a response
+        let response = Aeson.object
+              [ "jsonrpc" .= ("2.0" :: Text)
+              , "result"  .= Aeson.Null
+              , "id"      .= (1 :: Int)
+              ]
+        sendAll clientSock (LBS.toStrict (Aeson.encode response) <> "\n")
+      )
+      $ do
+        ipc <- connectIPC sockPath
+        let handle = ipcP2PHandle ipc
+        p2hPublish handle TopicBeaconBlock (BS.pack [1, 2, 3])
+        threadDelay 50000
+
+        got <- readIORef received
+        -- The received data should contain "publish" and "beacon_block"
+        assertBool "should contain method 'publish'"
+          (BS.isInfixOf (encodeUtf8 "publish") got)
+        assertBool "should contain topic 'beacon_block'"
+          (BS.isInfixOf (encodeUtf8 "beacon_block") got)
+
+-- | Test that subscribe receives notifications from sidecar.
+testSubscribe :: IO ()
+testSubscribe =
+  withSystemTempDirectory "lc-test-ipc-sub" $ \tmpDir -> do
+    let sockPath = tmpDir <> "/test.sock"
+    callbackData <- newEmptyMVar
+
+    withMockSidecar sockPath
+      (\clientSock _bs -> do
+        -- Respond to subscribe, then send a notification
+        let response = Aeson.object
+              [ "jsonrpc" .= ("2.0" :: Text)
+              , "result"  .= Aeson.Null
+              , "id"      .= (1 :: Int)
+              ]
+        sendAll clientSock (LBS.toStrict (Aeson.encode response) <> "\n")
+        threadDelay 50000
+
+        -- Send a message notification
+        let dataHex = decodeUtf8 (Base16.encode (BS.pack [0xCA, 0xFE]))
+            notification = Aeson.object
+              [ "jsonrpc" .= ("2.0" :: Text)
+              , "method"  .= ("message" :: Text)
+              , "params"  .= Aeson.object
+                  [ "topic" .= ("beacon_block" :: Text)
+                  , "data"  .= dataHex
+                  ]
+              ]
+        sendAll clientSock (LBS.toStrict (Aeson.encode notification) <> "\n")
+      )
+      $ do
+        ipc <- connectIPC sockPath
+        let handle = ipcP2PHandle ipc
+
+        p2hSubscribe handle TopicBeaconBlock $ \msg ->
+          putMVar callbackData msg
+
+        -- Wait for the notification to arrive
+        threadDelay 200000
+        result <- takeMVar callbackData
+        result @?= BS.pack [0xCA, 0xFE]
+
+-- | Test that peer_count returns the value from sidecar.
+testPeerCount :: IO ()
+testPeerCount =
+  withSystemTempDirectory "lc-test-ipc-peers" $ \tmpDir -> do
+    let sockPath = tmpDir <> "/test.sock"
+
+    withMockSidecar sockPath
+      (\clientSock _bs -> do
+        let response = Aeson.object
+              [ "jsonrpc" .= ("2.0" :: Text)
+              , "result"  .= (42 :: Int)
+              , "id"      .= (1 :: Int)
+              ]
+        sendAll clientSock (LBS.toStrict (Aeson.encode response) <> "\n")
+      )
+      $ do
+        ipc <- connectIPC sockPath
+        let handle = ipcP2PHandle ipc
+        count <- p2hPeerCount handle
+        count @?= 42

--- a/test/Test/Validator.hs
+++ b/test/Test/Validator.hs
@@ -1,0 +1,275 @@
+module Test.Validator (tests) where
+
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import Control.Concurrent (threadDelay)
+import Control.Concurrent.STM
+
+import Actor (Actor (..), spawnActor)
+import Consensus.StateTransition (getProposerIndex, processSlot)
+import Consensus.Types (Store (..), XmssPubkey)
+import Crypto.KeyManager (newManagedKey)
+import Crypto.LeanSig (PrivateKey, generateKeyPair)
+import Crypto.SigningRoot (computeDomain)
+import Genesis (initializeGenesis)
+import NodeTypes
+import SSZ.Common (zeroN)
+import Storage (withStorage, writeForkChoiceStore)
+import Validator (ValidatorEnv (..), validatorLoop)
+
+import Test.Support.Helpers
+    ( mkTestValidator
+    , mkTestGenesisState
+    , mkTestGenesis
+    )
+
+import qualified Data.ByteString.Char8 as BS8
+import System.IO.Temp (withSystemTempDirectory)
+
+tests :: TestTree
+tests = testGroup "Validator"
+  [ testCase "should detect proposal duty correctly" testProposalDutyDetection
+  , testCase "should propose block when designated proposer" testBlockProposal
+  , testCase "should create attestation on slot tick" testAttestationCreation
+  , testCase "should not propose when not the proposer" testNoProposalWhenNotProposer
+  , testCase "integration: validator produces attestations through multiple slots" testMultiSlotIntegration
+  ]
+
+-- | Test that getProposerIndex correctly identifies the proposer.
+testProposalDutyDetection :: IO ()
+testProposalDutyDetection = do
+  let vals = [ mkTestValidator 0 32000000000
+             , mkTestValidator 1 32000000000
+             , mkTestValidator 2 32000000000
+             , mkTestValidator 3 32000000000
+             ]
+      gs = mkTestGenesisState vals
+
+  -- At slot 0, proposer should be validator 0 (0 mod 4 == 0)
+  getProposerIndex gs @?= 0
+
+  -- At slot 1, proposer should be validator 1
+  let gs1 = processSlot gs
+  getProposerIndex gs1 @?= 1
+
+  -- At slot 2, proposer should be validator 2
+  let gs2 = processSlot gs1
+  getProposerIndex gs2 @?= 2
+
+-- | Test that the validator proposes a block when it is the designated proposer.
+testBlockProposal :: IO ()
+testBlockProposal =
+  withSystemTempDirectory "lc-test-val-propose" $ \tmpDir -> do
+    let genesis = mkTestGenesis
+        (gs, store) = initializeGenesis genesis
+
+    (privKey, pubKey) <- forceKeyPair "test-proposer-seed-0"
+    managedKey <- newManagedKey privKey pubKey
+    let domain = computeDomain (zeroN @4) (zeroN @4) (zeroN @32)
+        keyPath = tmpDir <> "/validator.key"
+        storePath = tmpDir <> "/db"
+
+    bcMsgs <- newTVarIO ([] :: [BlockchainMsg])
+    p2pMsgs <- newTVarIO ([] :: [P2PMsg])
+    bcActor <- spawnActor "test-bc" (trackingLoop bcMsgs)
+    p2pActor <- spawnActor "test-p2p" (trackingLoop p2pMsgs)
+
+    withStorage storePath gs store $ \sh -> do
+      atomically $ writeForkChoiceStore sh (store { stCurrentSlot = 1 })
+
+      -- With 2 validators, slot 2 mod 2 == 0, so validator 0 is proposer at slot 2
+      atomically $ writeForkChoiceStore sh (store { stCurrentSlot = 2 })
+
+      let env = ValidatorEnv
+            { veStorage        = sh
+            , veManagedKey     = managedKey
+            , veValidatorIndex = 0
+            , veDomain         = domain
+            , veKeyPersistPath = keyPath
+            , veBcActor        = bcActor
+            , veP2PActor       = p2pActor
+            }
+
+      valActor <- spawnActor "test-validator" (validatorLoop env)
+      atomically $ writeTQueue (actorQueue valActor) (ValSlotTick 2)
+      threadDelay 200000
+
+      msgs <- readTVarIO bcMsgs
+      assertBool "should have proposed a block" (any isBlockMsg msgs)
+      assertBool "should have created an attestation" (any isAttMsg msgs)
+
+      shutdownActors [valActor] bcActor p2pActor
+
+-- | Test that attestations are created every slot.
+testAttestationCreation :: IO ()
+testAttestationCreation =
+  withSystemTempDirectory "lc-test-val-attest" $ \tmpDir -> do
+    let genesis = mkTestGenesis
+        (gs, store) = initializeGenesis genesis
+
+    (privKey, pubKey) <- forceKeyPair "test-attester-seed-1"
+    managedKey <- newManagedKey privKey pubKey
+    let domain = computeDomain (zeroN @4) (zeroN @4) (zeroN @32)
+        keyPath = tmpDir <> "/validator.key"
+        storePath = tmpDir <> "/db"
+
+    bcMsgs <- newTVarIO ([] :: [BlockchainMsg])
+    p2pMsgs <- newTVarIO ([] :: [P2PMsg])
+    bcActor <- spawnActor "test-bc" (trackingLoop bcMsgs)
+    p2pActor <- spawnActor "test-p2p" (trackingLoop p2pMsgs)
+
+    withStorage storePath gs store $ \sh -> do
+      atomically $ writeForkChoiceStore sh (store { stCurrentSlot = 1 })
+
+      let env = ValidatorEnv
+            { veStorage        = sh
+            , veManagedKey     = managedKey
+            , veValidatorIndex = 1
+            , veDomain         = domain
+            , veKeyPersistPath = keyPath
+            , veBcActor        = bcActor
+            , veP2PActor       = p2pActor
+            }
+
+      valActor <- spawnActor "test-validator" (validatorLoop env)
+      atomically $ writeTQueue (actorQueue valActor) (ValSlotTick 1)
+      threadDelay 200000
+
+      msgs <- readTVarIO bcMsgs
+      assertBool "should have at least one attestation" (any isAttMsg msgs)
+
+      p2ps <- readTVarIO p2pMsgs
+      assertBool "should have published attestation to P2P" (any isP2PAttMsg p2ps)
+
+      shutdownActors [valActor] bcActor p2pActor
+
+-- | Test that a non-proposer validator does not propose a block.
+testNoProposalWhenNotProposer :: IO ()
+testNoProposalWhenNotProposer =
+  withSystemTempDirectory "lc-test-val-nopropose" $ \tmpDir -> do
+    let genesis = mkTestGenesis
+        (gs, store) = initializeGenesis genesis
+
+    (privKey, pubKey) <- forceKeyPair "test-non-proposer-seed"
+    managedKey <- newManagedKey privKey pubKey
+    let domain = computeDomain (zeroN @4) (zeroN @4) (zeroN @32)
+        keyPath = tmpDir <> "/validator.key"
+        storePath = tmpDir <> "/db"
+
+    bcMsgs <- newTVarIO ([] :: [BlockchainMsg])
+    bcActor <- spawnActor "test-bc" (trackingLoop bcMsgs)
+    p2pActor <- spawnActor "test-p2p" (sinkLoop @P2PMsg)
+
+    withStorage storePath gs store $ \sh -> do
+      atomically $ writeForkChoiceStore sh (store { stCurrentSlot = 1 })
+
+      let env = ValidatorEnv
+            { veStorage        = sh
+            , veManagedKey     = managedKey
+            , veValidatorIndex = 99
+            , veDomain         = domain
+            , veKeyPersistPath = keyPath
+            , veBcActor        = bcActor
+            , veP2PActor       = p2pActor
+            }
+
+      valActor <- spawnActor "test-validator" (validatorLoop env)
+      atomically $ writeTQueue (actorQueue valActor) (ValSlotTick 1)
+      threadDelay 200000
+
+      msgs <- readTVarIO bcMsgs
+      let blockCount = length (filter isBlockMsg msgs)
+      blockCount @?= 0
+
+      shutdownActors [valActor] bcActor p2pActor
+
+-- | Integration test: run validator through multiple slots.
+testMultiSlotIntegration :: IO ()
+testMultiSlotIntegration =
+  withSystemTempDirectory "lc-test-val-multi" $ \tmpDir -> do
+    let genesis = mkTestGenesis
+        (gs, store) = initializeGenesis genesis
+
+    (privKey, pubKey) <- forceKeyPair "test-multi-slot-seed"
+    managedKey <- newManagedKey privKey pubKey
+    let domain = computeDomain (zeroN @4) (zeroN @4) (zeroN @32)
+        keyPath = tmpDir <> "/validator.key"
+        storePath = tmpDir <> "/db"
+
+    bcMsgs <- newTVarIO ([] :: [BlockchainMsg])
+    bcActor <- spawnActor "test-bc" (trackingLoop bcMsgs)
+    p2pActor <- spawnActor "test-p2p" (sinkLoop @P2PMsg)
+
+    withStorage storePath gs store $ \sh -> do
+      atomically $ writeForkChoiceStore sh (store { stCurrentSlot = 5 })
+
+      let env = ValidatorEnv
+            { veStorage        = sh
+            , veManagedKey     = managedKey
+            , veValidatorIndex = 0
+            , veDomain         = domain
+            , veKeyPersistPath = keyPath
+            , veBcActor        = bcActor
+            , veP2PActor       = p2pActor
+            }
+
+      valActor <- spawnActor "test-validator" (validatorLoop env)
+
+      mapM_ (\slot -> do
+        atomically $ writeTQueue (actorQueue valActor) (ValSlotTick slot)
+        threadDelay 100000
+        ) [1, 2, 3]
+
+      threadDelay 100000
+
+      msgs <- readTVarIO bcMsgs
+      let attCount = length (filter isAttMsg msgs)
+      assertBool ("should have >= 3 attestations, got " <> show attCount) (attCount >= 3)
+
+      shutdownActors [valActor] bcActor p2pActor
+
+-- ---------------------------------------------------------------------------
+-- Helpers
+-- ---------------------------------------------------------------------------
+
+forceKeyPair :: String -> IO (PrivateKey, XmssPubkey)
+forceKeyPair seedStr =
+  case generateKeyPair 10 (BS8.pack seedStr) of
+    Right kp -> pure kp
+    Left e   -> error ("key gen failed: " <> show e)
+
+-- | A loop that records all messages in a TVar.
+trackingLoop :: TVar [msg] -> TQueue msg -> IO ()
+trackingLoop var queue = go
+  where
+    go = do
+      msg <- atomically $ readTQueue queue
+      atomically $ modifyTVar' var (msg :)
+      go
+
+-- | A loop that silently consumes all messages.
+sinkLoop :: forall msg. TQueue msg -> IO ()
+sinkLoop queue = go
+  where
+    go = do
+      _ <- atomically $ readTQueue queue
+      go
+
+shutdownActors :: [Actor ValidatorMsg] -> Actor BlockchainMsg -> Actor P2PMsg -> IO ()
+shutdownActors valActors bcActor p2pActor = do
+  mapM_ (\v -> atomically $ writeTQueue (actorQueue v) ValShutdown) valActors
+  atomically $ writeTQueue (actorQueue bcActor) BcShutdown
+  atomically $ writeTQueue (actorQueue p2pActor) P2PShutdown
+
+isBlockMsg :: BlockchainMsg -> Bool
+isBlockMsg (BcNewBlock _) = True
+isBlockMsg _              = False
+
+isAttMsg :: BlockchainMsg -> Bool
+isAttMsg (BcNewAttestation _) = True
+isAttMsg _                    = False
+
+isP2PAttMsg :: P2PMsg -> Bool
+isP2PAttMsg (P2PPublishAttestation _) = True
+isP2PAttMsg _                        = False


### PR DESCRIPTION
## Summary

- **Phase 6A (Validator Actor)**: Replace the no-op `validatorLoop` stub with a functional validator that proposes blocks and creates attestations based on slot duties. Extracts message types to `NodeTypes` module to break circular dependencies.
- **Phase 6B (P2P IPC Backend)**: Implement `Network.P2P.IPC` module providing a `P2PHandle` backed by JSON-RPC 2.0 over Unix domain socket, enabling communication with a libp2p Rust sidecar process. Adds `--p2p-socket` CLI option.

### New files
- `src/NodeTypes.hs` — shared message types (`BlockchainMsg`, `P2PMsg`, `ValidatorMsg`)
- `src/Validator.hs` — `ValidatorEnv`, `validatorLoop`, `proposeBlock`, `createAttestation`
- `src/Network/P2P/IPC.hs` — JSON-RPC IPC client for libp2p sidecar
- `test/Test/Validator.hs` — 5 tests (duty detection, block proposal, attestation, non-proposer, multi-slot)
- `test/Test/Network/IPC.hs` — 3 tests (publish, subscribe notifications, peer count)
- `docs/dev/07-p2p-ipc-protocol.md` — IPC protocol specification

### Modified files
- `src/Node.hs` — wire `ValidatorEnv` into `startNode`, import from `NodeTypes`
- `src/Config.hs` — add `ncP2PSocket` field
- `app/Options.hs` — add `--p2p-socket` CLI option
- `lean-consensus.cabal` — add new modules and `network` dependency

## Test plan

- [x] All 271 tests pass (`cabal test`)
- [x] 5 new validator tests: proposal duty detection, block proposal when proposer, attestation creation, no-proposal when not proposer, multi-slot integration
- [x] 3 new IPC tests: publish sends JSON-RPC, subscribe receives notifications, peer_count returns value
- [x] All 263 existing tests remain green (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)