### PR TITLE
refactor(leanSpec): split AggregatedAttestation from SignedAggregatedAttestation

### DIFF
--- a/src/Consensus/ForkChoice.hs
+++ b/src/Consensus/ForkChoice.hs
@@ -50,7 +50,7 @@ data ForkChoiceError
 initStore :: BeaconState -> BeaconBlock -> Store
 initStore genesisState genesisBlock =
   let blockRoot = toRoot genesisBlock
-      checkpoint = Checkpoint 0 blockRoot
+      checkpoint = Checkpoint blockRoot 0
   in  Store
     { stJustifiedCheckpoint = checkpoint
     , stFinalizedCheckpoint = checkpoint

--- a/src/Consensus/ForkChoice.hs
+++ b/src/Consensus/ForkChoice.hs
@@ -124,7 +124,7 @@ updateLatestMessagesFromBlock store block =
   in  foldl' (\s att ->
         let ad = aaData att
             bits = aaAggregationBits att
-            headRoot = adHeadRoot ad
+            headRoot = cpRoot (adHead ad)
             attSlot = adSlot ad
             numBits = bitlistLen bits
             voterIndices =
@@ -163,7 +163,7 @@ onAttestation store sa = do
     then Left (AttestationSlotInFuture attSlot (stCurrentSlot store))
     else Right ()
 
-  let store1 = updateLatestMessage store vi attSlot (adHeadRoot ad)
+  let store1 = updateLatestMessage store vi attSlot (cpRoot (adHead ad))
   Right store1
 
 -- ---------------------------------------------------------------------------

--- a/src/Consensus/ForkChoice.hs
+++ b/src/Consensus/ForkChoice.hs
@@ -20,8 +20,7 @@ import Data.Ord (comparing, Down (..))
 import Consensus.Constants
 import Consensus.Types
 import Consensus.StateTransition
-    ( isActiveValidator
-    , stateTransition
+    ( stateTransition
     )
 import SSZ.Bitlist (bitlistLen, getBitlistBit)
 import SSZ.Common (mkBytesN, unBytesN)
@@ -207,21 +206,15 @@ getWeight store root =
           , msgRoot == root || isDescendant store root msgRoot
           ]
 
--- | Get effective balance of an active non-slashed validator.
+-- | Flat weight: each validator contributes 1 (no balance weighting in leanSpec).
 getValidatorWeight :: Store -> ValidatorIndex -> Gwei
 getValidatorWeight store vi =
   let justRoot = cpRoot (stJustifiedCheckpoint store)
   in  case Map.lookup justRoot (stBlockStates store) of
         Nothing -> 0
         Just bs ->
-          let validators = unSszList (bsValidators bs)
-              idx = fromIntegral vi
-          in  if idx < length validators
-                then let v = validators !! idx
-                     in  if isActiveValidator v (bsSlot bs)
-                           then vEffectiveBalance v
-                           else 0
-                else 0
+          let numVals = length (unSszList (bsValidators bs))
+          in  if fromIntegral vi < numVals then 1 else 0
 
 -- | Get ancestor of a block at a target slot.
 getAncestor :: Store -> Root -> Slot -> Maybe Root

--- a/src/Consensus/StateTransition.hs
+++ b/src/Consensus/StateTransition.hs
@@ -135,7 +135,7 @@ processAttestation bs att = do
     else Right ()
 
   let targetRoot = cpRoot (adTargetCheckpoint ad)
-      numValidators = fromIntegral (cfgNumValidators (bsConfig bs)) :: Int
+      numValidators = length (unSszList (bsValidators bs))
       bits = aaAggregationBits att
       numBits = bitlistLen bits
 
@@ -198,7 +198,7 @@ processAttestations = foldl' step . Right
 processJustificationFinalization :: BeaconState -> BeaconState
 processJustificationFinalization bs =
   let validators = unSszList (bsValidators bs)
-      numValidators = fromIntegral (cfgNumValidators (bsConfig bs)) :: Int
+      numValidators = length validators
       totalActive = sum
         [ vEffectiveBalance v
         | v <- validators

--- a/src/Consensus/StateTransition.hs
+++ b/src/Consensus/StateTransition.hs
@@ -224,7 +224,7 @@ processJustificationFinalization bs =
           let (bestSlotIdx, bestRoot, _) = foldl1
                 (\a@(s1, _, _) b@(s2, _, _) -> if s1 >= s2 then a else b) xs
               bestSlot = fromIntegral bestSlotIdx :: Slot
-              newCp = Checkpoint bestSlot bestRoot
+              newCp = Checkpoint bestRoot bestSlot
               -- Mark the slot as justified in justified_slots
               currentJSlots = bsJustifiedSlots bs
               currentJLen = bitlistLen currentJSlots

--- a/src/Consensus/StateTransition.hs
+++ b/src/Consensus/StateTransition.hs
@@ -49,23 +49,17 @@ data StateTransitionError
 -- Validator helpers
 -- ---------------------------------------------------------------------------
 
+-- | All validators are always active in leanSpec (no lifecycle).
 isActiveValidator :: Validator -> Slot -> Bool
-isActiveValidator v slot =
-  vActivationSlot v <= slot && slot < vExitSlot v && not (vSlashed v)
+isActiveValidator _ _ = True
 
--- | Proposer selection: slot % numActiveValidators.
+-- | Proposer selection: slot % numValidators.
 getProposerIndex :: BeaconState -> ValidatorIndex
 getProposerIndex bs =
-  let validators = unSszList (bsValidators bs)
-      activeIndices =
-        [ fromIntegral i :: ValidatorIndex
-        | (i, v) <- zip [(0 :: Int)..] validators
-        , isActiveValidator v (bsSlot bs)
-        ]
-      numActive = fromIntegral (length activeIndices) :: Word64
-  in  if numActive == 0
+  let numVals = fromIntegral (length (unSszList (bsValidators bs))) :: Word64
+  in  if numVals == 0
         then 0
-        else activeIndices !! fromIntegral (bsSlot bs `mod` numActive)
+        else bsSlot bs `mod` numVals
 
 -- ---------------------------------------------------------------------------
 -- Per-slot processing (leanSpec aligned)
@@ -199,22 +193,18 @@ processJustificationFinalization :: BeaconState -> BeaconState
 processJustificationFinalization bs =
   let validators = unSszList (bsValidators bs)
       numValidators = length validators
-      totalActive = sum
-        [ vEffectiveBalance v
-        | v <- validators
-        , isActiveValidator v (bsSlot bs)
-        ]
+      totalActive = fromIntegral numValidators :: Word64
 
       justRoots = unSszList (bsJustificationsRoots bs)
       justBits = bsJustificationsValidators bs
       justBitsLen = bitlistLen justBits
 
-      -- Check each slot for supermajority
+      -- Check each slot for supermajority (flat voting: 1 validator = 1 vote)
       slotVotes =
-        [ (slotIdx, justRoots !! slotIdx, voteWeight)
+        [ (slotIdx, justRoots !! slotIdx, voteCount)
         | slotIdx <- [0 .. length justRoots - 1]
-        , let voteWeight = countSlotVotes validators numValidators justBits justBitsLen slotIdx (bsSlot bs)
-        , voteWeight * 3 >= totalActive * 2
+        , let voteCount = countSlotVotes numValidators justBits justBitsLen slotIdx
+        , voteCount * 3 >= totalActive * 2
         ]
 
       -- Find the latest justified slot
@@ -251,13 +241,14 @@ processJustificationFinalization bs =
          , bsJustifiedSlots  = newJustifiedSlots
          }
 
--- | Count the total vote weight for a slot in justifications_validators.
+-- | Count the number of votes for a slot in justifications_validators.
+-- Flat voting: each validator contributes 1 vote (no balance weighting).
 countSlotVotes
-  :: [Validator] -> Int -> Bitlist JUSTIFICATIONS_VALIDATORS_LIMIT -> Int -> Int -> Slot -> Gwei
-countSlotVotes validators numValidators justBits justBitsLen slotIdx currentSlot =
-  sum [ vEffectiveBalance v
-      | (vIdx, v) <- zip [0..] validators
-      , isActiveValidator v currentSlot
+  :: Int -> Bitlist JUSTIFICATIONS_VALIDATORS_LIMIT -> Int -> Int -> Word64
+countSlotVotes numValidators justBits justBitsLen slotIdx =
+  fromIntegral $ length
+      [ ()
+      | vIdx <- [0 .. numValidators - 1]
       , let bitIdx = slotIdx * numValidators + vIdx
       , bitIdx < justBitsLen
       , getBitlistBit justBits bitIdx

--- a/src/Consensus/StateTransition.hs
+++ b/src/Consensus/StateTransition.hs
@@ -128,7 +128,7 @@ processAttestation bs att = do
     then Left (InvalidAttestationSlot attSlot (bsSlot bs))
     else Right ()
 
-  let targetRoot = cpRoot (adTargetCheckpoint ad)
+  let targetRoot = cpRoot (adTarget ad)
       numValidators = length (unSszList (bsValidators bs))
       bits = aaAggregationBits att
       numBits = bitlistLen bits

--- a/src/Consensus/Types.hs
+++ b/src/Consensus/Types.hs
@@ -295,12 +295,9 @@ instance SszHashTreeRoot BeaconBlockHeader where
   hashTreeRoot = genericHashTreeRoot
 
 data Validator = Validator
-  { vPubkey           :: !XmssPubkey
-  , vEffectiveBalance :: !Gwei
-  , vSlashed          :: !Bool
-  , vActivationSlot   :: !Slot
-  , vExitSlot         :: !Slot
-  , vWithdrawableSlot :: !Slot
+  { vAttestationPubkey :: !XmssPubkey
+  , vProposalPubkey    :: !XmssPubkey
+  , vIndex             :: !ValidatorIndex
   } deriving stock (Generic, Eq, Show)
 
 instance Ssz Validator where

--- a/src/Consensus/Types.hs
+++ b/src/Consensus/Types.hs
@@ -17,6 +17,7 @@ module Consensus.Types
   , AttestationData (..)
   , SignedAttestation (..)
   , AggregatedAttestation (..)
+  , SignedAggregatedAttestation (..)
   , AggregatedSignatureProof (..)
   , BeaconBlockBody (..)
   , BeaconBlock (..)
@@ -187,10 +188,10 @@ instance SszDecode SignedAttestation where
 instance SszHashTreeRoot SignedAttestation where
   hashTreeRoot = genericHashTreeRoot
 
--- | Unsigned aggregated attestation (leanSpec: BlockBody.attestations element).
+-- | Unsigned aggregated attestation (leanSpec: aggregation_bits first, then data).
 data AggregatedAttestation = AggregatedAttestation
-  { aaData            :: !AttestationData
-  , aaAggregationBits :: !AggregationBits
+  { aaAggregationBits :: !AggregationBits
+  , aaData            :: !AttestationData
   } deriving stock (Generic, Eq, Show)
 
 instance Ssz AggregatedAttestation where
@@ -200,6 +201,21 @@ instance SszEncode AggregatedAttestation where
 instance SszDecode AggregatedAttestation where
   sszDecode = genericSszDecode
 instance SszHashTreeRoot AggregatedAttestation where
+  hashTreeRoot = genericHashTreeRoot
+
+-- | Signed aggregated attestation (leanSpec: contains data + proof).
+data SignedAggregatedAttestation = SignedAggregatedAttestation
+  { saaData  :: !AggregatedAttestation
+  , saaProof :: !AggregatedSignatureProof
+  } deriving stock (Generic, Eq, Show)
+
+instance Ssz SignedAggregatedAttestation where
+  sszFixedSize = genericSszFixedSize @(Rep SignedAggregatedAttestation)
+instance SszEncode SignedAggregatedAttestation where
+  sszEncode = genericSszEncode
+instance SszDecode SignedAggregatedAttestation where
+  sszDecode = genericSszDecode
+instance SszHashTreeRoot SignedAggregatedAttestation where
   hashTreeRoot = genericHashTreeRoot
 
 -- | Aggregated signature proof (leanSpec: BlockSignatures.attestation_signatures element).

--- a/src/Consensus/Types.hs
+++ b/src/Consensus/Types.hs
@@ -143,8 +143,8 @@ instance SszHashTreeRoot Config where
 -- ---------------------------------------------------------------------------
 
 data Checkpoint = Checkpoint
-  { cpSlot :: !Slot
-  , cpRoot :: !Root
+  { cpRoot :: !Root
+  , cpSlot :: !Slot
   } deriving stock (Generic, Eq, Ord, Show)
 
 instance Ssz Checkpoint where

--- a/src/Consensus/Types.hs
+++ b/src/Consensus/Types.hs
@@ -157,10 +157,10 @@ instance SszHashTreeRoot Checkpoint where
   hashTreeRoot = genericHashTreeRoot
 
 data AttestationData = AttestationData
-  { adSlot             :: !Slot
-  , adHeadRoot         :: !Root
-  , adSourceCheckpoint :: !Checkpoint
-  , adTargetCheckpoint :: !Checkpoint
+  { adSlot   :: !Slot
+  , adHead   :: !Checkpoint
+  , adTarget :: !Checkpoint
+  , adSource :: !Checkpoint
   } deriving stock (Generic, Eq, Ord, Show)
 
 instance Ssz AttestationData where

--- a/src/Consensus/Types.hs
+++ b/src/Consensus/Types.hs
@@ -126,7 +126,7 @@ type AggregationBits = Bitlist VALIDATOR_REGISTRY_LIMIT
 -- ---------------------------------------------------------------------------
 
 data Config = Config
-  { cfgNumValidators :: !Word64
+  { cfgGenesisTime :: !Word64
   } deriving stock (Generic, Eq, Show)
 
 instance Ssz Config where

--- a/src/Crypto/Operations.hs
+++ b/src/Crypto/Operations.hs
@@ -90,7 +90,7 @@ aggregateAttestations _prover attestations _committee _domain _subnetId = do
               bits = [ fromIntegral i `elem` valIndices | i <- [(0 :: Int) .. numVals - 1] ]
           case mkBitlist bits of
             Left _sszErr -> pure (Left (AggregationFailed "bitlist construction failed"))
-            Right bitlist -> pure (Right (AggregatedAttestation firstData bitlist))
+            Right bitlist -> pure (Right (AggregatedAttestation bitlist firstData))
 
 -- | Verify an aggregated attestation.
 verifyAggregatedAttestation :: VerifierContext -> AggregatedAttestation

--- a/src/Genesis.hs
+++ b/src/Genesis.hs
@@ -17,6 +17,7 @@ import qualified Data.ByteString.Base16 as Base16
 import qualified Data.Text as T
 import Data.Text.Encoding (encodeUtf8)
 import Data.Time.Clock (UTCTime)
+import Data.Time.Clock.POSIX (utcTimeToPOSIXSeconds)
 import Data.Time.Format (defaultTimeLocale, parseTimeM)
 import Data.Word (Word64)
 
@@ -89,8 +90,8 @@ parseHexField fieldName hexStr = do
 initializeGenesisState :: GenesisConfig -> BeaconState
 initializeGenesisState gc =
   let validators = map toValidator (gcValidators gc)
-      numVals = fromIntegral (length validators) :: Word64
-      config = Config { cfgNumValidators = numVals }
+      genesisTimeUnix = floor (utcTimeToPOSIXSeconds (gcGenesisTime gc)) :: Word64
+      config = Config { cfgGenesisTime = genesisTimeUnix }
       valList    = forceRight $ mkSszList @VALIDATORS_LIMIT validators
       emptyHashes = forceRight $ mkSszList @HISTORICAL_BLOCK_HASHES_LIMIT []
       emptyJSlots = forceRight $ mkBitlist @JUSTIFIED_SLOTS_LIMIT []

--- a/src/Genesis.hs
+++ b/src/Genesis.hs
@@ -35,8 +35,8 @@ import SSZ.Common (mkBytesN)
 -- ---------------------------------------------------------------------------
 
 data GenesisValidator = GenesisValidator
-  { gvPubkey  :: !XmssPubkey
-  , gvBalance :: !Gwei
+  { gvAttestationPubkey :: !XmssPubkey
+  , gvProposalPubkey    :: !XmssPubkey
   } deriving stock (Eq, Show)
 
 data GenesisConfig = GenesisConfig
@@ -52,12 +52,17 @@ data GenesisConfig = GenesisConfig
 
 instance FromJSON GenesisValidator where
   parseJSON = withObject "GenesisValidator" $ \o -> do
-    pubkeyHex <- o .: "pubkey"
-    balance   <- o .: "balance"
-    pubkeyBs  <- parseHexField "pubkey" pubkeyHex
-    case mkXmssPubkey pubkeyBs of
-      Left err -> fail $ "Invalid pubkey: " <> show err
-      Right pk -> pure $ GenesisValidator pk balance
+    attPubkeyHex  <- o .: "attestation_pubkey"
+    propPubkeyHex <- o .: "proposal_pubkey"
+    attBs  <- parseHexField "attestation_pubkey" attPubkeyHex
+    propBs <- parseHexField "proposal_pubkey" propPubkeyHex
+    attPk  <- case mkXmssPubkey attBs of
+      Left err -> fail $ "Invalid attestation_pubkey: " <> show err
+      Right pk -> pure pk
+    propPk <- case mkXmssPubkey propBs of
+      Left err -> fail $ "Invalid proposal_pubkey: " <> show err
+      Right pk -> pure pk
+    pure $ GenesisValidator attPk propPk
 
 instance FromJSON GenesisConfig where
   parseJSON = withObject "GenesisConfig" $ \o -> do
@@ -89,7 +94,7 @@ parseHexField fieldName hexStr = do
 -- | Build the genesis BeaconState from configuration (leanSpec 10-field model).
 initializeGenesisState :: GenesisConfig -> BeaconState
 initializeGenesisState gc =
-  let validators = map toValidator (gcValidators gc)
+  let validators = zipWith toValidator [0..] (gcValidators gc)
       genesisTimeUnix = floor (utcTimeToPOSIXSeconds (gcGenesisTime gc)) :: Word64
       config = Config { cfgGenesisTime = genesisTimeUnix }
       valList    = forceRight $ mkSszList @VALIDATORS_LIMIT validators
@@ -135,14 +140,11 @@ parseGenesisConfig = Aeson.eitherDecode
 -- Internal helpers
 -- ---------------------------------------------------------------------------
 
-toValidator :: GenesisValidator -> Validator
-toValidator gv = Validator
-  { vPubkey           = gvPubkey gv
-  , vEffectiveBalance = gvBalance gv
-  , vSlashed          = False
-  , vActivationSlot   = 0
-  , vExitSlot         = maxBound
-  , vWithdrawableSlot = maxBound
+toValidator :: ValidatorIndex -> GenesisValidator -> Validator
+toValidator idx gv = Validator
+  { vAttestationPubkey = gvAttestationPubkey gv
+  , vProposalPubkey    = gvProposalPubkey gv
+  , vIndex             = idx
   }
 
 mkEmptyBody :: BeaconBlockBody

--- a/src/Genesis.hs
+++ b/src/Genesis.hs
@@ -153,7 +153,7 @@ zeroRoot :: Root
 zeroRoot = zeroN @32
 
 zeroCheckpoint :: Checkpoint
-zeroCheckpoint = Checkpoint 0 zeroRoot
+zeroCheckpoint = Checkpoint zeroRoot 0
 
 toRoot :: SszHashTreeRoot a => a -> Root
 toRoot a = case mkBytesN @32 (hashTreeRoot a) of

--- a/src/Network/Aggregator.hs
+++ b/src/Network/Aggregator.hs
@@ -114,7 +114,7 @@ aggregatorLoop env = do
     Nothing -> pure ()
     Just bs -> do
       let validators = unSszList (bsValidators bs)
-          pubkeys = [ vPubkey v | v <- validators ]
+          pubkeys = [ vAttestationPubkey v | v <- validators ]
           domain = aeDomain env
 
       -- Aggregate each group with timeout

--- a/src/Node.hs
+++ b/src/Node.hs
@@ -168,7 +168,7 @@ findValidatorIndex :: GenesisConfig -> XmssPubkey -> ValidatorIndex
 findValidatorIndex gc pubKey =
   case [ fromIntegral i :: ValidatorIndex
        | (i, gv) <- zip [(0 :: Int)..] (gcValidators gc)
-       , gvPubkey gv == pubKey
+       , gvAttestationPubkey gv == pubKey || gvProposalPubkey gv == pubKey
        ] of
     (idx : _) -> idx
     []        -> 0

--- a/src/Validator.hs
+++ b/src/Validator.hs
@@ -96,7 +96,7 @@ createAttestation :: ValidatorEnv -> BeaconState -> Store -> Slot -> IO ()
 createAttestation env state store slot = do
   let headRoot = getHead store
       source = bsLatestJustified state
-      target = Checkpoint slot headRoot
+      target = Checkpoint headRoot slot
 
       attData = AttestationData
         { adSlot             = slot

--- a/src/Validator.hs
+++ b/src/Validator.hs
@@ -96,13 +96,14 @@ createAttestation :: ValidatorEnv -> BeaconState -> Store -> Slot -> IO ()
 createAttestation env state store slot = do
   let headRoot = getHead store
       source = bsLatestJustified state
+      head_  = Checkpoint headRoot slot
       target = Checkpoint headRoot slot
 
       attData = AttestationData
-        { adSlot             = slot
-        , adHeadRoot         = headRoot
-        , adSourceCheckpoint = source
-        , adTargetCheckpoint = target
+        { adSlot   = slot
+        , adHead   = head_
+        , adTarget = target
+        , adSource = source
         }
 
   result <- signAttestation

--- a/test/Test/Consensus/ForkChoice.hs
+++ b/test/Test/Consensus/ForkChoice.hs
@@ -44,12 +44,12 @@ mkBlockSignatures =
   let emptyAttSigs = forceRight $ mkSszList @MAX_ATTESTATION_SIGNATURES []
   in  BlockSignatures emptyAttSigs zeroSig
 
-mkValidatorWithPubkey :: Word8 -> Gwei -> Validator
-mkValidatorWithPubkey w balance =
+mkValidatorWithPubkey :: Word8 -> ValidatorIndex -> Validator
+mkValidatorWithPubkey w idx =
   let pk = case mkXmssPubkey (BS.replicate xmssPubkeySize w) of
              Right p -> p
              Left _  -> error "mkValidatorWithPubkey failed"
-  in  Validator pk balance False 0 maxBound maxBound
+  in  Validator pk pk idx
 
 mkGenesisState :: [Validator] -> BeaconState
 mkGenesisState vals =
@@ -94,7 +94,7 @@ tests :: TestTree
 tests = testGroup "Consensus.ForkChoice"
   [ testGroup "initStore"
       [ testCase "genesis head is genesis block root" $ do
-          let gs = mkGenesisState [mkValidatorWithPubkey 1 32000000]
+          let gs = mkGenesisState [mkValidatorWithPubkey 1 0]
               gb = mkGenesisBlock
               store = initStore gs gb
               head' = getHead store
@@ -103,14 +103,14 @@ tests = testGroup "Consensus.ForkChoice"
       ]
   , testGroup "getHead"
       [ testCase "returns genesis with no other blocks" $ do
-          let gs = mkGenesisState [mkValidatorWithPubkey 1 32000000]
+          let gs = mkGenesisState [mkValidatorWithPubkey 1 0]
               gb = mkGenesisBlock
               store = initStore gs gb
           getHead store @?= toRoot gb
       ]
   , testGroup "onAttestation"
       [ testCase "updates latest message" $ do
-          let gs = mkGenesisState [mkValidatorWithPubkey 1 32000000]
+          let gs = mkGenesisState [mkValidatorWithPubkey 1 0]
               gb = mkGenesisBlock
               store = initStore gs gb
               gbRoot = toRoot gb
@@ -126,7 +126,7 @@ tests = testGroup "Consensus.ForkChoice"
                 Nothing -> assertFailure "Expected latest message"
             Left err -> assertFailure $ show err
       , testCase "rejects future attestation" $ do
-          let gs = mkGenesisState [mkValidatorWithPubkey 1 32000000]
+          let gs = mkGenesisState [mkValidatorWithPubkey 1 0]
               gb = mkGenesisBlock
               store = initStore gs gb
               ad = AttestationData 5 zeroRoot zeroCheckpoint zeroCheckpoint
@@ -137,13 +137,13 @@ tests = testGroup "Consensus.ForkChoice"
       ]
   , testGroup "getAncestor"
       [ testCase "finds self at same slot" $ do
-          let gs = mkGenesisState [mkValidatorWithPubkey 1 32000000]
+          let gs = mkGenesisState [mkValidatorWithPubkey 1 0]
               gb = mkGenesisBlock
               store = initStore gs gb
               gbRoot = toRoot gb
           getAncestor store gbRoot 0 @?= Just gbRoot
       , testCase "returns Nothing for future slot" $ do
-          let gs = mkGenesisState [mkValidatorWithPubkey 1 32000000]
+          let gs = mkGenesisState [mkValidatorWithPubkey 1 0]
               gb = mkGenesisBlock
               store = initStore gs gb
               gbRoot = toRoot gb
@@ -151,13 +151,13 @@ tests = testGroup "Consensus.ForkChoice"
       ]
   , testGroup "isDescendant"
       [ testCase "block is descendant of itself" $ do
-          let gs = mkGenesisState [mkValidatorWithPubkey 1 32000000]
+          let gs = mkGenesisState [mkValidatorWithPubkey 1 0]
               gb = mkGenesisBlock
               store = initStore gs gb
               gbRoot = toRoot gb
           isDescendant store gbRoot gbRoot @?= True
       , testCase "unknown root is not a descendant" $ do
-          let gs = mkGenesisState [mkValidatorWithPubkey 1 32000000]
+          let gs = mkGenesisState [mkValidatorWithPubkey 1 0]
               gb = mkGenesisBlock
               store = initStore gs gb
               gbRoot = toRoot gb
@@ -165,7 +165,7 @@ tests = testGroup "Consensus.ForkChoice"
       ]
   , testGroup "onBlock"
       [ testCase "rejects orphan block" $ do
-          let gs = mkGenesisState [mkValidatorWithPubkey 1 32000000]
+          let gs = mkGenesisState [mkValidatorWithPubkey 1 0]
               gb = mkGenesisBlock
               store = initStore gs gb
               orphanBlock = BeaconBlock 1 0 (mkRoot 99) zeroRoot mkEmptyBody
@@ -174,7 +174,7 @@ tests = testGroup "Consensus.ForkChoice"
             Left OrphanBlock -> pure ()
             other -> assertFailure $ "Expected OrphanBlock, got: " ++ show other
       , testCase "rejects future block" $ do
-          let gs = mkGenesisState [mkValidatorWithPubkey 1 32000000]
+          let gs = mkGenesisState [mkValidatorWithPubkey 1 0]
               gb = mkGenesisBlock
               store = initStore gs gb
               futureBlock = BeaconBlock 5 0 zeroRoot zeroRoot mkEmptyBody
@@ -185,7 +185,7 @@ tests = testGroup "Consensus.ForkChoice"
       ]
   , testGroup "getWeight"
       [ testCase "zero weight with no attestations" $ do
-          let gs = mkGenesisState [mkValidatorWithPubkey 1 32000000]
+          let gs = mkGenesisState [mkValidatorWithPubkey 1 0]
               gb = mkGenesisBlock
               store = initStore gs gb
           getWeight store (toRoot gb) @?= 0

--- a/test/Test/Consensus/ForkChoice.hs
+++ b/test/Test/Consensus/ForkChoice.hs
@@ -53,8 +53,7 @@ mkValidatorWithPubkey w balance =
 
 mkGenesisState :: [Validator] -> BeaconState
 mkGenesisState vals =
-  let numVals = fromIntegral (length vals)
-      config = Config { cfgNumValidators = numVals }
+  let config = Config { cfgGenesisTime = 0 }
       valList = forceRight $ mkSszList @VALIDATORS_LIMIT vals
       emptyHashes = forceRight $ mkSszList @HISTORICAL_BLOCK_HASHES_LIMIT []
       emptyJSlots = forceRight $ mkBitlist @JUSTIFIED_SLOTS_LIMIT []

--- a/test/Test/Consensus/ForkChoice.hs
+++ b/test/Test/Consensus/ForkChoice.hs
@@ -114,7 +114,8 @@ tests = testGroup "Consensus.ForkChoice"
               gb = mkGenesisBlock
               store = initStore gs gb
               gbRoot = toRoot gb
-              ad = AttestationData 0 gbRoot zeroCheckpoint zeroCheckpoint
+              headCp = Checkpoint gbRoot 0
+              ad = AttestationData 0 headCp zeroCheckpoint zeroCheckpoint
               sa = SignedAttestation ad 0 zeroSig
           case onAttestation store sa of
             Right store1 -> do
@@ -129,7 +130,7 @@ tests = testGroup "Consensus.ForkChoice"
           let gs = mkGenesisState [mkValidatorWithPubkey 1 0]
               gb = mkGenesisBlock
               store = initStore gs gb
-              ad = AttestationData 5 zeroRoot zeroCheckpoint zeroCheckpoint
+              ad = AttestationData 5 zeroCheckpoint zeroCheckpoint zeroCheckpoint
               sa = SignedAttestation ad 0 zeroSig
           case onAttestation store sa of
             Left (AttestationSlotInFuture 5 0) -> pure ()

--- a/test/Test/Consensus/ForkChoice.hs
+++ b/test/Test/Consensus/ForkChoice.hs
@@ -37,7 +37,7 @@ zeroSig = case mkXmssSignature (BS.replicate xmssSignatureSize 0) of
   Left _  -> error "zeroSig failed"
 
 zeroCheckpoint :: Checkpoint
-zeroCheckpoint = Checkpoint 0 zeroRoot
+zeroCheckpoint = Checkpoint zeroRoot 0
 
 mkBlockSignatures :: BlockSignatures
 mkBlockSignatures =

--- a/test/Test/Consensus/Integration.hs
+++ b/test/Test/Consensus/Integration.hs
@@ -27,7 +27,7 @@ zeroRoot :: Root
 zeroRoot = zeroN @32
 
 zeroCheckpoint :: Checkpoint
-zeroCheckpoint = Checkpoint 0 zeroRoot
+zeroCheckpoint = Checkpoint zeroRoot 0
 
 zeroSig :: XmssSignature
 zeroSig = case mkXmssSignature (BS.replicate xmssSignatureSize 0) of

--- a/test/Test/Consensus/Integration.hs
+++ b/test/Test/Consensus/Integration.hs
@@ -48,8 +48,7 @@ mkValidatorWithPubkey w balance =
 
 mkGenesisState :: [Validator] -> BeaconState
 mkGenesisState vals =
-  let numVals = fromIntegral (length vals)
-      config = Config { cfgNumValidators = numVals }
+  let config = Config { cfgGenesisTime = 0 }
       valList = forceRight $ mkSszList @VALIDATORS_LIMIT vals
       emptyHashes = forceRight $ mkSszList @HISTORICAL_BLOCK_HASHES_LIMIT []
       emptyJSlots = forceRight $ mkBitlist @JUSTIFIED_SLOTS_LIMIT []

--- a/test/Test/Consensus/Integration.hs
+++ b/test/Test/Consensus/Integration.hs
@@ -39,12 +39,12 @@ mkBlockSignatures =
   let emptyAttSigs = forceRight $ mkSszList @MAX_ATTESTATION_SIGNATURES []
   in  BlockSignatures emptyAttSigs zeroSig
 
-mkValidatorWithPubkey :: Word8 -> Gwei -> Validator
-mkValidatorWithPubkey w balance =
+mkValidatorWithPubkey :: Word8 -> ValidatorIndex -> Validator
+mkValidatorWithPubkey w idx =
   let pk = case mkXmssPubkey (BS.replicate xmssPubkeySize w) of
              Right p -> p
              Left _  -> error "mkValidatorWithPubkey"
-  in  Validator pk balance False 0 maxBound maxBound
+  in  Validator pk pk idx
 
 mkGenesisState :: [Validator] -> BeaconState
 mkGenesisState vals =
@@ -85,7 +85,7 @@ forceRight (Left _)  = error "forceRight: unexpected Left"
 tests :: TestTree
 tests = testGroup "Consensus.Integration"
   [ testCase "state transition advances slot and updates header" $ do
-      let vals = [mkValidatorWithPubkey 1 32000000]
+      let vals = [mkValidatorWithPubkey 1 0]
           gs = mkGenesisState vals
           gs1 = processSlot gs  -- slot 0 -> 1
           parentRoot = toRoot (bsLatestBlockHeader gs1)
@@ -104,9 +104,9 @@ tests = testGroup "Consensus.Integration"
         Left err -> assertFailure $ "State transition failed: " ++ show err
 
   , testCase "fork choice selects heavier chain" $ do
-      let vals = [ mkValidatorWithPubkey 1 32000000
-                 , mkValidatorWithPubkey 2 32000000
-                 , mkValidatorWithPubkey 3 32000000
+      let vals = [ mkValidatorWithPubkey 1 0
+                 , mkValidatorWithPubkey 2 1
+                 , mkValidatorWithPubkey 3 2
                  ]
           gs = mkGenesisState vals
           genesisBlock = BeaconBlock 0 0 zeroRoot zeroRoot mkEmptyBody

--- a/test/Test/Consensus/StateTransition.hs
+++ b/test/Test/Consensus/StateTransition.hs
@@ -63,8 +63,7 @@ mkValidatorWithPubkey w balance =
 
 mkGenesisState :: [Validator] -> BeaconState
 mkGenesisState vals =
-  let numVals = fromIntegral (length vals)
-      config = Config { cfgNumValidators = numVals }
+  let config = Config { cfgGenesisTime = 0 }
       valList = forceRight $ mkSszList @VALIDATORS_LIMIT vals
       emptyHashes = forceRight $ mkSszList @HISTORICAL_BLOCK_HASHES_LIMIT []
       emptyJSlots = forceRight $ mkBitlist @JUSTIFIED_SLOTS_LIMIT []

--- a/test/Test/Consensus/StateTransition.hs
+++ b/test/Test/Consensus/StateTransition.hs
@@ -44,22 +44,19 @@ mkBlockSignatures =
   let emptyAttSigs = forceRight $ mkSszList @MAX_ATTESTATION_SIGNATURES []
   in  BlockSignatures emptyAttSigs zeroSig
 
-mkValidator :: Gwei -> Slot -> Slot -> Validator
-mkValidator balance activationSlot exitSlot = Validator
-  { vPubkey           = zeroPubkey
-  , vEffectiveBalance = balance
-  , vSlashed          = False
-  , vActivationSlot   = activationSlot
-  , vExitSlot         = exitSlot
-  , vWithdrawableSlot = maxBound
+mkValidator :: ValidatorIndex -> Validator
+mkValidator idx = Validator
+  { vAttestationPubkey = zeroPubkey
+  , vProposalPubkey    = zeroPubkey
+  , vIndex             = idx
   }
 
-mkValidatorWithPubkey :: Word8 -> Gwei -> Validator
-mkValidatorWithPubkey w balance =
+mkValidatorWithPubkey :: Word8 -> ValidatorIndex -> Validator
+mkValidatorWithPubkey w idx =
   let pk = case mkXmssPubkey (BS.replicate xmssPubkeySize w) of
              Right p -> p
              Left _  -> error "mkValidatorWithPubkey failed"
-  in  Validator pk balance False 0 maxBound maxBound
+  in  Validator pk pk idx
 
 mkGenesisState :: [Validator] -> BeaconState
 mkGenesisState vals =
@@ -100,57 +97,44 @@ forceRight (Left _)  = error "forceRight: unexpected Left"
 tests :: TestTree
 tests = testGroup "Consensus.StateTransition"
   [ testGroup "isActiveValidator"
-      [ testCase "active at slot within range" $ do
-          let v = mkValidator 32000000 0 100
+      [ testCase "always active in leanSpec" $ do
+          let v = mkValidator 0
+          isActiveValidator v 0 @?= True
           isActiveValidator v 50 @?= True
-      , testCase "inactive before activation" $ do
-          let v = mkValidator 32000000 10 100
-          isActiveValidator v 5 @?= False
-      , testCase "inactive at exit slot" $ do
-          let v = mkValidator 32000000 0 100
-          isActiveValidator v 100 @?= False
-      , testCase "inactive if slashed" $ do
-          let v = (mkValidator 32000000 0 100) { vSlashed = True }
-          isActiveValidator v 50 @?= False
-      , testCase "active at exact activation slot" $ do
-          let v = mkValidator 32000000 10 100
-          isActiveValidator v 10 @?= True
-      , testCase "active one slot before exit" $ do
-          let v = mkValidator 32000000 0 100
-          isActiveValidator v 99 @?= True
+          isActiveValidator v maxBound @?= True
       ]
   , testGroup "processSlots"
       [ testCase "no-op when target equals current" $ do
-          let bs = mkGenesisState [mkValidator 32000000 0 maxBound]
+          let bs = mkGenesisState [mkValidator 0]
           processSlots bs 0 @?= Right bs
       , testCase "rejects target < current" $ do
-          let bs = (mkGenesisState [mkValidator 32000000 0 maxBound]) { bsSlot = 5 }
+          let bs = (mkGenesisState [mkValidator 0]) { bsSlot = 5 }
           case processSlots bs 3 of
             Left (SlotTooOld 3 5) -> pure ()
             other -> assertFailure $ "Expected SlotTooOld, got: " ++ show other
       , testCase "advances slot by 1" $ do
-          let bs = mkGenesisState [mkValidator 32000000 0 maxBound]
+          let bs = mkGenesisState [mkValidator 0]
           case processSlots bs 1 of
             Right bs1 -> bsSlot bs1 @?= 1
             Left err  -> assertFailure $ show err
       , testCase "advances multiple slots" $ do
-          let bs = mkGenesisState [mkValidator 32000000 0 maxBound]
+          let bs = mkGenesisState [mkValidator 0]
           case processSlots bs 5 of
             Right bs5 -> bsSlot bs5 @?= 5
             Left err  -> assertFailure $ show err
       ]
   , testGroup "processSlot"
       [ testCase "increments slot" $ do
-          let bs = mkGenesisState [mkValidator 32000000 0 maxBound]
+          let bs = mkGenesisState [mkValidator 0]
               bs1 = processSlot bs
           bsSlot bs1 @?= 1
       , testCase "appends block hash to historical_block_hashes" $ do
-          let bs = mkGenesisState [mkValidator 32000000 0 maxBound]
+          let bs = mkGenesisState [mkValidator 0]
               bs1 = processSlot bs
               hashes = unSszList (bsHistoricalBlockHashes bs1)
           length hashes @?= 1
       , testCase "accumulates historical block hashes over multiple slots" $ do
-          let bs = mkGenesisState [mkValidator 32000000 0 maxBound]
+          let bs = mkGenesisState [mkValidator 0]
           case processSlots bs 3 of
             Right bs3 -> do
               let hashes = unSszList (bsHistoricalBlockHashes bs3)
@@ -159,7 +143,7 @@ tests = testGroup "Consensus.StateTransition"
       ]
   , testGroup "processBlockHeader"
       [ testCase "valid block header" $ do
-          let vals = [mkValidatorWithPubkey 1 32000000]
+          let vals = [mkValidatorWithPubkey 1 0]
               bs = mkGenesisState vals
               bs1 = processSlot bs  -- advance to slot 1
               parentRoot = toRoot (bsLatestBlockHeader bs1)
@@ -174,7 +158,7 @@ tests = testGroup "Consensus.StateTransition"
             Right bs2 -> bbhSlot (bsLatestBlockHeader bs2) @?= 1
             Left err  -> assertFailure $ show err
       , testCase "rejects wrong slot" $ do
-          let bs = mkGenesisState [mkValidator 32000000 0 maxBound]
+          let bs = mkGenesisState [mkValidator 0]
               block = BeaconBlock 5 0 zeroRoot zeroRoot mkEmptyBody
           case processBlockHeader bs block of
             Left (InvalidSlot 5 0) -> pure ()
@@ -182,12 +166,12 @@ tests = testGroup "Consensus.StateTransition"
       ]
   , testGroup "getProposerIndex"
       [ testCase "deterministic with single active validator" $ do
-          let bs = mkGenesisState [mkValidator 32000000 0 maxBound]
+          let bs = mkGenesisState [mkValidator 0]
           getProposerIndex bs @?= 0
       , testCase "rotates with slot" $ do
-          let vals = [ mkValidatorWithPubkey 1 32000000
-                     , mkValidatorWithPubkey 2 32000000
-                     , mkValidatorWithPubkey 3 32000000
+          let vals = [ mkValidatorWithPubkey 1 0
+                     , mkValidatorWithPubkey 2 1
+                     , mkValidatorWithPubkey 3 2
                      ]
               bs0 = mkGenesisState vals
               bs1 = bs0 { bsSlot = 1 }
@@ -195,16 +179,17 @@ tests = testGroup "Consensus.StateTransition"
           getProposerIndex bs0 @?= 0
           getProposerIndex bs1 @?= 1
           getProposerIndex bs2 @?= 2
-      , testCase "skips inactive validators" $ do
-          let vals = [ mkValidator 32000000 10 maxBound   -- inactive at slot 0
-                     , mkValidatorWithPubkey 2 32000000   -- active
+      , testCase "all validators always active in leanSpec" $ do
+          let vals = [ mkValidator 0
+                     , mkValidatorWithPubkey 2 1
                      ]
               bs = mkGenesisState vals
-          getProposerIndex bs @?= 1
+          -- slot 0 mod 2 == 0, so validator 0 is proposer
+          getProposerIndex bs @?= 0
       ]
   , testGroup "stateTransition"
       [ testCase "advances slot and updates header" $ do
-          let vals = [mkValidatorWithPubkey 1 32000000]
+          let vals = [mkValidatorWithPubkey 1 0]
               bs = mkGenesisState vals
               bs1 = processSlot bs
               parentRoot = toRoot (bsLatestBlockHeader bs1)
@@ -224,7 +209,7 @@ tests = testGroup "Consensus.StateTransition"
       ]
   , testGroup "processAttestation"
       [ testCase "accepts valid past-slot attestation" $ do
-          let vals = [mkValidatorWithPubkey 1 32000000]
+          let vals = [mkValidatorWithPubkey 1 0]
               bs = (mkGenesisState vals) { bsSlot = 2 }
               bits = forceRight $ mkBitlist @VALIDATOR_REGISTRY_LIMIT [True]
               att = AggregatedAttestation
@@ -235,7 +220,7 @@ tests = testGroup "Consensus.StateTransition"
             Right _ -> pure ()
             Left err -> assertFailure $ "Expected success, got: " ++ show err
       , testCase "rejects future-slot attestation" $ do
-          let vals = [mkValidatorWithPubkey 1 32000000]
+          let vals = [mkValidatorWithPubkey 1 0]
               bs = (mkGenesisState vals) { bsSlot = 1 }
               bits = forceRight $ mkBitlist @VALIDATOR_REGISTRY_LIMIT [True]
               att = AggregatedAttestation
@@ -248,7 +233,7 @@ tests = testGroup "Consensus.StateTransition"
       ]
   , testGroup "processJustificationFinalization"
       [ testCase "no justification with no votes" $ do
-          let vals = [mkValidatorWithPubkey 1 32000000]
+          let vals = [mkValidatorWithPubkey 1 0]
               bs = mkGenesisState vals
               bs' = processJustificationFinalization bs
           bsLatestJustified bs' @?= zeroCheckpoint

--- a/test/Test/Consensus/StateTransition.hs
+++ b/test/Test/Consensus/StateTransition.hs
@@ -213,7 +213,7 @@ tests = testGroup "Consensus.StateTransition"
               bs = (mkGenesisState vals) { bsSlot = 2 }
               bits = forceRight $ mkBitlist @VALIDATOR_REGISTRY_LIMIT [True]
               att = AggregatedAttestation
-                { aaData = AttestationData 1 zeroRoot zeroCheckpoint zeroCheckpoint
+                { aaData = AttestationData 1 zeroCheckpoint zeroCheckpoint zeroCheckpoint
                 , aaAggregationBits = bits
                 }
           case processAttestation bs att of
@@ -224,7 +224,7 @@ tests = testGroup "Consensus.StateTransition"
               bs = (mkGenesisState vals) { bsSlot = 1 }
               bits = forceRight $ mkBitlist @VALIDATOR_REGISTRY_LIMIT [True]
               att = AggregatedAttestation
-                { aaData = AttestationData 5 zeroRoot zeroCheckpoint zeroCheckpoint
+                { aaData = AttestationData 5 zeroCheckpoint zeroCheckpoint zeroCheckpoint
                 , aaAggregationBits = bits
                 }
           case processAttestation bs att of

--- a/test/Test/Consensus/StateTransition.hs
+++ b/test/Test/Consensus/StateTransition.hs
@@ -32,7 +32,7 @@ zeroPubkey = case mkXmssPubkey (BS.replicate xmssPubkeySize 0) of
   Left _   -> error "zeroPubkey failed"
 
 zeroCheckpoint :: Checkpoint
-zeroCheckpoint = Checkpoint 0 zeroRoot
+zeroCheckpoint = Checkpoint zeroRoot 0
 
 zeroSig :: XmssSignature
 zeroSig = case mkXmssSignature (BS.replicate xmssSignatureSize 0) of

--- a/test/Test/Consensus/Types.hs
+++ b/test/Test/Consensus/Types.hs
@@ -24,7 +24,7 @@ zeroCheckpoint = Checkpoint zeroRoot 0
 
 -- | Create a zero AttestationData.
 zeroAttData :: AttestationData
-zeroAttData = AttestationData 0 zeroRoot zeroCheckpoint zeroCheckpoint
+zeroAttData = AttestationData 0 zeroCheckpoint zeroCheckpoint zeroCheckpoint
 
 -- | Create a zero BeaconBlockHeader.
 zeroBlockHeader :: BeaconBlockHeader
@@ -36,8 +36,8 @@ tests = testGroup "Consensus.Types"
       [ testCase "Checkpoint is fixed-size, 40 bytes" $ do
           sszFixedSize @Checkpoint @?= Just 40
           sszIsFixedSize @Checkpoint @?= True
-      , testCase "AttestationData is fixed-size, 120 bytes" $ do
-          sszFixedSize @AttestationData @?= Just 120
+      , testCase "AttestationData is fixed-size, 128 bytes" $ do
+          sszFixedSize @AttestationData @?= Just 128
           sszIsFixedSize @AttestationData @?= True
       , testCase "BeaconBlockHeader is fixed-size, 112 bytes" $ do
           sszFixedSize @BeaconBlockHeader @?= Just 112
@@ -65,7 +65,7 @@ tests = testGroup "Consensus.Types"
       , testCase "AttestationData" $ do
           let root = unsafeRight $ mkBytesN @32 (BS.pack [1..32])
               cp = Checkpoint root 10
-              ad = AttestationData 5 root cp cp
+              ad = AttestationData 5 cp cp cp
           sszDecode (sszEncode ad) @?= Right ad
       , testCase "SignedAttestation" $ do
           let sig = unsafeRight $ mkXmssSignature (BS.replicate xmssSignatureSize 0xAB)

--- a/test/Test/Consensus/Types.hs
+++ b/test/Test/Consensus/Types.hs
@@ -52,10 +52,9 @@ tests = testGroup "Consensus.Types"
           sszIsFixedSize @Validator @?= True
       , testCase "AggregatedSignatureProof is variable-size" $
           sszIsFixedSize @AggregatedSignatureProof @?= False
-      , testCase "Validator size uses xmssPubkeySize" $ do
-          -- vPubkey(32) + vEffectiveBalance(8) + vSlashed(1) +
-          -- vActivationSlot(8) + vExitSlot(8) + vWithdrawableSlot(8) = 65
-          let expectedSize = fromIntegral xmssPubkeySize + 8 + 1 + 8 + 8 + 8
+      , testCase "Validator size is 112 bytes (52+52+8)" $ do
+          -- vAttestationPubkey(52) + vProposalPubkey(52) + vIndex(8) = 112
+          let expectedSize = fromIntegral xmssPubkeySize + fromIntegral xmssPubkeySize + 8
           sszFixedSize @Validator @?= Just expectedSize
       ]
   , testGroup "roundtrip"
@@ -78,7 +77,7 @@ tests = testGroup "Consensus.Types"
           sszDecode (sszEncode bbh) @?= Right bbh
       , testCase "Validator" $ do
           let pk = unsafeRight $ mkXmssPubkey (BS.replicate xmssPubkeySize 0x01)
-              v = Validator pk 32000000 False 0 maxBound maxBound
+              v = Validator pk pk 0
           sszDecode (sszEncode v) @?= Right v
       , testCase "AggregatedSignatureProof (empty)" $ do
           let asp = AggregatedSignatureProof (LeanMultisigProof "")

--- a/test/Test/Consensus/Types.hs
+++ b/test/Test/Consensus/Types.hs
@@ -20,7 +20,7 @@ zeroRoot = zeroN @32
 
 -- | Create a zero Checkpoint.
 zeroCheckpoint :: Checkpoint
-zeroCheckpoint = Checkpoint 0 zeroRoot
+zeroCheckpoint = Checkpoint zeroRoot 0
 
 -- | Create a zero AttestationData.
 zeroAttData :: AttestationData
@@ -61,11 +61,11 @@ tests = testGroup "Consensus.Types"
   , testGroup "roundtrip"
       [ testCase "Checkpoint" $ do
           let root = unsafeRight $ mkBytesN @32 (BS.pack [1..32])
-              cp = Checkpoint 42 root
+              cp = Checkpoint root 42
           sszDecode (sszEncode cp) @?= Right cp
       , testCase "AttestationData" $ do
           let root = unsafeRight $ mkBytesN @32 (BS.pack [1..32])
-              cp = Checkpoint 10 root
+              cp = Checkpoint root 10
               ad = AttestationData 5 root cp cp
           sszDecode (sszEncode ad) @?= Right ad
       , testCase "SignedAttestation" $ do
@@ -89,10 +89,10 @@ tests = testGroup "Consensus.Types"
       ]
   , testGroup "hashTreeRoot"
       [ testCase "Checkpoint hashTreeRoot" $ do
-          let cp = Checkpoint 0 zeroRoot
-              slotRoot = hashTreeRoot (0 :: Word64)
+          let cp = Checkpoint zeroRoot 0
               rootRoot = hashTreeRoot zeroRoot
-              expected = merkleize [slotRoot, rootRoot] 2
+              slotRoot = hashTreeRoot (0 :: Word64)
+              expected = merkleize [rootRoot, slotRoot] 2
           hashTreeRoot cp @?= expected
       , testCase "BeaconBlockHeader hashTreeRoot" $ do
           let bbh = zeroBlockHeader

--- a/test/Test/Crypto/Operations.hs
+++ b/test/Test/Crypto/Operations.hs
@@ -31,9 +31,9 @@ testDomain = zeroN @32
 testAttData :: AttestationData
 testAttData = AttestationData
   { adSlot = 42
-  , adHeadRoot = zeroN @32
-  , adSourceCheckpoint = Checkpoint (zeroN @32) 0
-  , adTargetCheckpoint = Checkpoint (zeroN @32) 1
+  , adHead   = Checkpoint (zeroN @32) 0
+  , adTarget = Checkpoint (zeroN @32) 1
+  , adSource = Checkpoint (zeroN @32) 0
   }
 
 -- | Helper: create a test beacon block.

--- a/test/Test/Crypto/Operations.hs
+++ b/test/Test/Crypto/Operations.hs
@@ -32,8 +32,8 @@ testAttData :: AttestationData
 testAttData = AttestationData
   { adSlot = 42
   , adHeadRoot = zeroN @32
-  , adSourceCheckpoint = Checkpoint 0 (zeroN @32)
-  , adTargetCheckpoint = Checkpoint 1 (zeroN @32)
+  , adSourceCheckpoint = Checkpoint (zeroN @32) 0
+  , adTargetCheckpoint = Checkpoint (zeroN @32) 1
   }
 
 -- | Helper: create a test beacon block.

--- a/test/Test/Genesis.hs
+++ b/test/Test/Genesis.hs
@@ -62,8 +62,8 @@ sampleGenesisJson :: BL.ByteString
 sampleGenesisJson = BL.pack $ concat
   [ "{\"genesis_time\":\"2026-01-01T00:00:00Z\""
   , ",\"validators\":["
-  , "{\"pubkey\":\"0x" <> replicate 104 '0' <> "\",\"balance\":32000000000}"
-  , ",{\"pubkey\":\"0x" <> replicate 104 'a' <> "\",\"balance\":32000000000}"
+  , "{\"attestation_pubkey\":\"0x" <> replicate 104 '0' <> "\",\"proposal_pubkey\":\"0x" <> replicate 104 '0' <> "\"}"
+  , ",{\"attestation_pubkey\":\"0x" <> replicate 104 'a' <> "\",\"proposal_pubkey\":\"0x" <> replicate 104 'a' <> "\"}"
   , "]"
   , ",\"fork_version\":\"0x00000001\""
   , ",\"chain_id\":1337"

--- a/test/Test/Integration/Devnet.hs
+++ b/test/Test/Integration/Devnet.hs
@@ -26,7 +26,7 @@ import Test.Support.MockNetwork
 tests :: TestTree
 tests = testGroup "Integration.Devnet"
   [ testCase "genesis sync: node syncs blocks from peers after genesis init" $ do
-      let vals = [mkTestValidator 1 32000000]
+      let vals = [mkTestValidator 1 0]
           gs = mkTestGenesisState vals
           genesisBlock = mkTestGenesisBlock
 
@@ -49,7 +49,7 @@ tests = testGroup "Integration.Devnet"
         11 (Map.size (stBlocks store))
 
   , testCase "block following: node receives and validates new blocks via gossip" $ do
-      let vals = [mkTestValidator 1 32000000]
+      let vals = [mkTestValidator 1 0]
           gs = mkTestGenesisState vals
           genesisBlock = mkTestGenesisBlock
 
@@ -122,7 +122,7 @@ tests = testGroup "Integration.Devnet"
         stopNode actors
 
   , testCase "sync then gossip: sync history then follow live blocks" $ do
-      let vals = [mkTestValidator 1 32000000]
+      let vals = [mkTestValidator 1 0]
           gs = mkTestGenesisState vals
           genesisBlock = mkTestGenesisBlock
 
@@ -163,7 +163,7 @@ tests = testGroup "Integration.Devnet"
         7 (Map.size (stBlocks storeFinal))
 
   , testCase "multi-node consensus: two nodes agree on chain head" $ do
-      let vals = [mkTestValidator 1 32000000]
+      let vals = [mkTestValidator 1 0]
           gs = mkTestGenesisState vals
           genesisBlock = mkTestGenesisBlock
 

--- a/test/Test/Network/Aggregator.hs
+++ b/test/Test/Network/Aggregator.hs
@@ -14,7 +14,8 @@ tests = testGroup "Network.Aggregator"
   [ testCase "addAttestation groups by AttestationData" $ do
       pool <- newAttestationPool
       let genesisRoot = toRoot mkTestGenesisBlock
-          ad1 = AttestationData 1 genesisRoot zeroCheckpoint zeroCheckpoint
+          headCp = Checkpoint genesisRoot 1
+          ad1 = AttestationData 1 headCp zeroCheckpoint zeroCheckpoint
           att1 = mkTestAttestation 0 1 genesisRoot zeroCheckpoint zeroCheckpoint
           att2 = mkTestAttestation 1 1 genesisRoot zeroCheckpoint zeroCheckpoint
       atomically $ do

--- a/test/Test/Network/Integration.hs
+++ b/test/Test/Network/Integration.hs
@@ -111,7 +111,7 @@ tests = testGroup "Network.Integration"
           domain = cpRoot genCp
 
       let pubkeys = [ vPubkey v | v <- unSszList (bsValidators st1) ]
-          target1 = Checkpoint 1 block1Root
+          target1 = Checkpoint block1Root 1
           subnetVis = [ vi | vi <- [0 .. 7 :: Int], vi `mod` 4 == 0 ]
           atts = [ mkSignedTestAttestation (privKeys !! i) (fromIntegral i)
                      1 block1Root genCp target1 domain

--- a/test/Test/Network/Integration.hs
+++ b/test/Test/Network/Integration.hs
@@ -29,7 +29,7 @@ unsafeRight (Left e)  = error ("unexpected Left: " <> show e)
 tests :: TestTree
 tests = testGroup "Network.Integration"
   [ testCase "two-node block gossip via MockNetwork" $ do
-      let vals = [mkTestValidator 1 32000000]
+      let vals = [mkTestValidator 1 0]
           gs = mkTestGenesisState vals
           genesisBlock = mkTestGenesisBlock
 
@@ -65,7 +65,7 @@ tests = testGroup "Network.Integration"
         (Map.size (stBlocks store2) >= 2)
 
   , testCase "attestation flow: validator -> message handler" $ do
-      let vals = [mkTestValidator 1 32000000]
+      let vals = [mkTestValidator 1 0]
           gs = mkTestGenesisState vals
           genesisBlock = mkTestGenesisBlock
           genesisRoot = toRoot genesisBlock
@@ -95,7 +95,7 @@ tests = testGroup "Network.Integration"
         (Map.member 0 (stLatestMessages store))
 
   , testCase "aggregation flow: pool -> aggregate -> publish to TopicAggregation" $ do
-      let keyVals = [ mkTestValidatorWithKey i 32000000 | i <- [0..7] ]
+      let keyVals = [ mkTestValidatorWithKey i | i <- [0..7] ]
           privKeys = map fst keyVals
           vals = map snd keyVals
           gs = mkTestGenesisState vals
@@ -110,7 +110,7 @@ tests = testGroup "Network.Integration"
           genCp = zeroCheckpoint
           domain = cpRoot genCp
 
-      let pubkeys = [ vPubkey v | v <- unSszList (bsValidators st1) ]
+      let pubkeys = [ vAttestationPubkey v | v <- unSszList (bsValidators st1) ]
           target1 = Checkpoint block1Root 1
           subnetVis = [ vi | vi <- [0 .. 7 :: Int], vi `mod` 4 == 0 ]
           atts = [ mkSignedTestAttestation (privKeys !! i) (fromIntegral i)
@@ -147,7 +147,7 @@ tests = testGroup "Network.Integration"
             (Map.member TopicAggregation published)
 
   , testCase "sync then live gossip: sync 5 blocks then receive block 6 via gossip" $ do
-      let vals = [mkTestValidator 1 32000000]
+      let vals = [mkTestValidator 1 0]
           gs = mkTestGenesisState vals
           genesisBlock = mkTestGenesisBlock
 

--- a/test/Test/Network/MessageHandler.hs
+++ b/test/Test/Network/MessageHandler.hs
@@ -60,7 +60,7 @@ seenCacheTests = testGroup "SeenCache"
 blockValidationTests :: TestTree
 blockValidationTests = testGroup "Block validation"
   [ testCase "valid block is accepted" $ do
-      let vals = [mkTestValidator 1 32000000]
+      let vals = [mkTestValidator 1 0]
           gs = mkTestGenesisState vals
           store = initStore gs mkTestGenesisBlock
           sbb = mkTestSignedBlock gs 1
@@ -68,14 +68,14 @@ blockValidationTests = testGroup "Block validation"
       validateBlock store1 sbb 1 @?= Accept
 
   , testCase "future block is rejected" $ do
-      let vals = [mkTestValidator 1 32000000]
+      let vals = [mkTestValidator 1 0]
           gs = mkTestGenesisState vals
           store = initStore gs mkTestGenesisBlock
       let farBlock = SignedBeaconBlock (BeaconBlock 100 0 zeroRoot zeroRoot mkEmptyBody) mkBlockSignatures
       validateBlock store farBlock 0 @?= Reject
 
   , testCase "orphan block is ignored" $ do
-      let vals = [mkTestValidator 1 32000000]
+      let vals = [mkTestValidator 1 0]
           gs = mkTestGenesisState vals
           store = initStore gs mkTestGenesisBlock
           orphanParent = case mkBytesN @32 (BS.replicate 32 0xFF) of
@@ -93,7 +93,7 @@ blockValidationTests = testGroup "Block validation"
 attestationValidationTests :: TestTree
 attestationValidationTests = testGroup "Attestation validation"
   [ testCase "valid attestation is accepted" $ do
-      let vals = [mkTestValidator 1 32000000]
+      let vals = [mkTestValidator 1 0]
           gs = mkTestGenesisState vals
           genesisBlock = mkTestGenesisBlock
           store = initStore gs genesisBlock
@@ -102,14 +102,14 @@ attestationValidationTests = testGroup "Attestation validation"
       validateAttestation (store { stCurrentSlot = 1 }) att 1 @?= Accept
 
   , testCase "future attestation is rejected" $ do
-      let vals = [mkTestValidator 1 32000000]
+      let vals = [mkTestValidator 1 0]
           gs = mkTestGenesisState vals
           store = initStore gs mkTestGenesisBlock
           att = mkTestAttestation 0 10 zeroRoot zeroCheckpoint zeroCheckpoint
       validateAttestation store att 0 @?= Reject
 
   , testCase "old attestation is ignored" $ do
-      let vals = [mkTestValidator 1 32000000]
+      let vals = [mkTestValidator 1 0]
           gs = mkTestGenesisState vals
           store = initStore gs mkTestGenesisBlock
           att = mkTestAttestation 0 0 zeroRoot zeroCheckpoint zeroCheckpoint

--- a/test/Test/Network/RPC.hs
+++ b/test/Test/Network/RPC.hs
@@ -61,7 +61,7 @@ tests = testGroup "Network.RPC"
 
 withTestStorage :: (StorageHandle -> IO a) -> IO a
 withTestStorage f = do
-  let vals = [mkTestValidator 0 32000000000, mkTestValidator 1 32000000000]
+  let vals = [mkTestValidator 0 0, mkTestValidator 1 1]
       gs = mkTestGenesisState vals
       gb = mkTestGenesisBlock
       store = initStore gs gb

--- a/test/Test/Network/Sync.hs
+++ b/test/Test/Network/Sync.hs
@@ -17,7 +17,7 @@ import Test.Support.MockNetwork
 tests :: TestTree
 tests = testGroup "Network.Sync"
   [ testCase "onBlock accepts blocks built by stateTransition" $ do
-      let vals = [mkTestValidator 1 32000000]
+      let vals = [mkTestValidator 1 0]
           gs = mkTestGenesisState vals
           genesisBlock = mkTestGenesisBlock
           store0 = initStore gs genesisBlock
@@ -30,7 +30,7 @@ tests = testGroup "Network.Sync"
           Map.size (stBlocks store2) @?= 2
 
   , testCase "syncBatch applies one block" $ do
-      let vals = [mkTestValidator 1 32000000]
+      let vals = [mkTestValidator 1 0]
           gs = mkTestGenesisState vals
           genesisBlock = mkTestGenesisBlock
           sbb1 = mkTestSignedBlock gs 1
@@ -48,7 +48,7 @@ tests = testGroup "Network.Sync"
         Right slot -> slot @?= 1
 
   , testCase "sync from genesis to slot 3" $ do
-      let vals = [mkTestValidator 1 32000000]
+      let vals = [mkTestValidator 1 0]
           gs = mkTestGenesisState vals
           genesisBlock = mkTestGenesisBlock
 
@@ -84,7 +84,7 @@ tests = testGroup "Network.Sync"
                   stCurrentSlot store @?= 3
 
   , testCase "sync with no blocks needed returns Synced" $ do
-      let vals = [mkTestValidator 1 32000000]
+      let vals = [mkTestValidator 1 0]
           gs = mkTestGenesisState vals
           genesisBlock = mkTestGenesisBlock
 

--- a/test/Test/Storage.hs
+++ b/test/Test/Storage.hs
@@ -32,7 +32,7 @@ tests = testGroup "Storage"
 
 mkEnv :: (BeaconState -> Store -> [SignedBeaconBlock] -> [BeaconState] -> IO a) -> IO a
 mkEnv action = do
-  let vals = [mkTestValidator i 32 | i <- [1..4]]
+  let vals = [mkTestValidator i (fromIntegral (i - 1)) | i <- [1..4]]
       gs   = mkTestGenesisState vals
       gb   = mkTestGenesisBlock
       store = initStore gs gb
@@ -111,7 +111,7 @@ testPrune = mkEnv $ \gs _store blocks _states ->
 -- | 4 async threads each put+get 10 blocks, no lost writes.
 testConcurrent :: Assertion
 testConcurrent = do
-  let vals = [mkTestValidator i 32 | i <- [1..4]]
+  let vals = [mkTestValidator i (fromIntegral (i - 1)) | i <- [1..4]]
       gs   = mkTestGenesisState vals
       gb   = mkTestGenesisBlock
       store = initStore gs gb

--- a/test/Test/Support/Helpers.hs
+++ b/test/Test/Support/Helpers.hs
@@ -53,7 +53,7 @@ zeroRoot :: Root
 zeroRoot = zeroN @32
 
 zeroCheckpoint :: Checkpoint
-zeroCheckpoint = Checkpoint 0 zeroRoot
+zeroCheckpoint = Checkpoint zeroRoot 0
 
 zeroSig :: XmssSignature
 zeroSig = case mkXmssSignature (BS.replicate xmssSignatureSize 0) of

--- a/test/Test/Support/Helpers.hs
+++ b/test/Test/Support/Helpers.hs
@@ -84,7 +84,8 @@ mkTestValidatorWithKey idx =
 mkSignedTestAttestation :: PrivateKey -> ValidatorIndex -> Slot -> Root
                         -> Checkpoint -> Checkpoint -> Domain -> SignedAttestation
 mkSignedTestAttestation privKey vi slot headRoot source target domain =
-  let attData = AttestationData slot headRoot source target
+  let headCp = Checkpoint headRoot slot
+      attData = AttestationData slot headCp target source
       signingRoot = computeSigningRoot attData domain
       message = unBytesN signingRoot
       sig = forceRight $ sign privKey message 0
@@ -180,8 +181,9 @@ buildChain gs n = go gs (1 :: Slot) n [] []
 
 mkTestAttestation :: ValidatorIndex -> Slot -> Root -> Checkpoint -> Checkpoint -> SignedAttestation
 mkTestAttestation vi slot headRoot source target =
-  SignedAttestation
-    { saData = AttestationData slot headRoot source target
+  let headCp = Checkpoint headRoot slot
+  in  SignedAttestation
+    { saData = AttestationData slot headCp target source
     , saValidatorIndex = vi
     , saSignature = zeroSig
     }

--- a/test/Test/Support/Helpers.hs
+++ b/test/Test/Support/Helpers.hs
@@ -65,20 +65,20 @@ mkBlockSignatures =
   let emptyAttSigs = forceRight $ mkSszList @MAX_ATTESTATION_SIGNATURES []
   in  BlockSignatures emptyAttSigs zeroSig
 
-mkTestValidator :: Word8 -> Gwei -> Validator
-mkTestValidator w balance =
+mkTestValidator :: Word8 -> ValidatorIndex -> Validator
+mkTestValidator w idx =
   let pk = case mkXmssPubkey (BS.replicate xmssPubkeySize w) of
              Right p -> p
              Left _  -> error "mkTestValidator"
-  in  Validator pk balance False 0 maxBound maxBound
+  in  Validator pk pk idx
 
 -- | Create a validator with a real Ed25519-backed key pair for signing tests.
 -- Returns (PrivateKey, Validator).
-mkTestValidatorWithKey :: Int -> Gwei -> (PrivateKey, Validator)
-mkTestValidatorWithKey idx balance =
+mkTestValidatorWithKey :: Int -> (PrivateKey, Validator)
+mkTestValidatorWithKey idx =
   let seed = BS8.pack ("test-validator-seed-" <> show idx)
       (privKey, pubKey) = forceRight $ generateKeyPair 10 seed
-  in  (privKey, Validator pubKey balance False 0 maxBound maxBound)
+  in  (privKey, Validator pubKey pubKey (fromIntegral idx))
 
 -- | Create a properly signed attestation using a real private key.
 mkSignedTestAttestation :: PrivateKey -> ValidatorIndex -> Slot -> Root
@@ -129,8 +129,8 @@ mkTestGenesis =
                   Left _  -> error "mkTestGenesis: forkVersion"
   in  GenesisConfig
     { gcGenesisTime = UTCTime (fromGregorian 2026 1 1) 0
-    , gcValidators  = [ GenesisValidator pk1 32000000000
-                      , GenesisValidator pk2 32000000000
+    , gcValidators  = [ GenesisValidator pk1 pk1
+                      , GenesisValidator pk2 pk2
                       ]
     , gcForkVersion = forkVer
     , gcChainId     = 1337

--- a/test/Test/Support/Helpers.hs
+++ b/test/Test/Support/Helpers.hs
@@ -92,8 +92,7 @@ mkSignedTestAttestation privKey vi slot headRoot source target domain =
 
 mkTestGenesisState :: [Validator] -> BeaconState
 mkTestGenesisState vals =
-  let numVals = fromIntegral (length vals)
-      config = Config { cfgNumValidators = numVals }
+  let config = Config { cfgGenesisTime = 0 }
       valList = forceRight $ mkSszList @VALIDATORS_LIMIT vals
       emptyHashes = forceRight $ mkSszList @HISTORICAL_BLOCK_HASHES_LIMIT []
       emptyJSlots = forceRight $ mkBitlist @JUSTIFIED_SLOTS_LIMIT []

--- a/test/Test/Validator.hs
+++ b/test/Test/Validator.hs
@@ -39,10 +39,10 @@ tests = testGroup "Validator"
 -- | Test that getProposerIndex correctly identifies the proposer.
 testProposalDutyDetection :: IO ()
 testProposalDutyDetection = do
-  let vals = [ mkTestValidator 0 32000000000
-             , mkTestValidator 1 32000000000
-             , mkTestValidator 2 32000000000
-             , mkTestValidator 3 32000000000
+  let vals = [ mkTestValidator 0 0
+             , mkTestValidator 1 1
+             , mkTestValidator 2 2
+             , mkTestValidator 3 3
              ]
       gs = mkTestGenesisState vals
 


### PR DESCRIPTION
## Summary
- Swap `AggregatedAttestation` field order: `aggregation_bits` before `data` (leanSpec)
- Add new `SignedAggregatedAttestation` type: `{ saaData :: AggregatedAttestation, saaProof :: AggregatedSignatureProof }`
- Export `SignedAggregatedAttestation(..)` from `Consensus.Types`

Depends on #104 (issue #88)
Closes #90

## Test plan
- [x] `cabal build` compiles successfully
- [x] `cabal test` — all 260 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)